### PR TITLE
fix(ci): replace useState+useEffect dev-flag reader with useSyncExternalStore

### DIFF
--- a/frontend/src/app/components/scene/Layout.tsx
+++ b/frontend/src/app/components/scene/Layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useState, useSyncExternalStore } from "react";
 
 import Scene from "@/app/components/scene/Scene";
 import UpdateModal from "@/app/components/interface/misc/UpdateModal";
@@ -15,16 +15,16 @@ import { DevPanel } from "@/app/components/dev/DevPanel";
 
 const Layout: React.FC = () => {
   const [simParamsOpen, setSimParamsOpen] = useState(false);
-  const [devMode, setDevMode] = useState(false);
 
-  // Read ?dev=1 once on mount. The dev panel is gated rather than
-  // built into the user-facing chrome, so the gate doesn't need to
-  // re-evaluate mid-session.
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const params = new URLSearchParams(window.location.search);
-    setDevMode(params.has("dev"));
-  }, []);
+  // Read ?dev=… once on mount. useSyncExternalStore is the React-canonical
+  // pattern for "read an external value once" — SSR snapshot returns false
+  // (server has no window), client snapshot reads the URL on hydration.
+  // No re-subscription since the URL doesn't change mid-session.
+  const devMode = useSyncExternalStore(
+    () => () => {},
+    () => new URLSearchParams(window.location.search).has("dev"),
+    () => false,
+  );
 
   return (
     <div className="flex w-screen h-screen overflow-hidden">


### PR DESCRIPTION
## Summary
- Replaces the dev-mode URL-flag reader in [Layout.tsx](frontend/src/app/components/scene/Layout.tsx) with `useSyncExternalStore`, which is the React-canonical pattern for "read an external value once".
- Unblocks frontend CI on master — the prior `useState`+`useEffect` pattern triggered the `react-hooks/set-state-in-effect` lint rule.

## Why
Next.js no longer runs ESLint inside `next build` by default, so a clean local build doesn't catch this. The CI lint job did.

## Test plan
- [x] `npm run lint` — 0 errors locally (2 pre-existing warnings remain in Camera.tsx / Trail.tsx, unrelated)
- [x] `npm run build` — clean
- [x] `npm test` — 74/74 pass
- [ ] Browser smoke: load `/?dev=1` → DevPanel renders; load `/` → DevPanel hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)