### PR TITLE
Phase 2: ChunkBuffer module (typed-array buffer + accessors)

### DIFF
--- a/frontend/src/app/store/chunkBuffer.test.ts
+++ b/frontend/src/app/store/chunkBuffer.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { createChunkBuffer, CHUNK_SIZE } from "./chunkBuffer";
+
+describe("createChunkBuffer", () => {
+  it("allocates positions and timestamps sized for the given capacity", () => {
+    const buf = createChunkBuffer(["Earth", "Moon"], 1000);
+    expect(buf.bodyCount).toBe(2);
+    expect(buf.bodyNames).toEqual(["Earth", "Moon"]);
+    expect(buf.bodyNameToIndex.get("Earth")).toBe(0);
+    expect(buf.bodyNameToIndex.get("Moon")).toBe(1);
+    expect(buf.positions.length).toBe(1000 * 2 * 6);
+    expect(buf.timestamps.length).toBe(1000);
+    expect(buf.totalTimesteps).toBe(0);
+    expect(buf.bufferStartTimestep).toBe(0);
+    expect(buf.capacity).toBe(1000);
+  });
+
+  it("exports CHUNK_SIZE", () => {
+    expect(CHUNK_SIZE).toBe(10_000);
+  });
+});

--- a/frontend/src/app/store/chunkBuffer.test.ts
+++ b/frontend/src/app/store/chunkBuffer.test.ts
@@ -5,7 +5,27 @@ import {
   computeBufferCapacity,
   selectBufferByteBudget,
   BUFFER_BYTE_BUDGETS,
+  appendChunk,
 } from "./chunkBuffer";
+
+function makeChunkPositions(
+  bodyCount: number,
+  timestepCount: number,
+  startValue = 0,
+): Float64Array {
+  const arr = new Float64Array(bodyCount * timestepCount * 6);
+  for (let i = 0; i < arr.length; i++) arr[i] = startValue + i;
+  return arr;
+}
+
+function makeChunkTimestamps(
+  timestepCount: number,
+  startMillis = 0n,
+): BigInt64Array {
+  const arr = new BigInt64Array(timestepCount);
+  for (let i = 0; i < timestepCount; i++) arr[i] = startMillis + BigInt(i);
+  return arr;
+}
 
 describe("createChunkBuffer", () => {
   it("allocates positions and timestamps sized for the given capacity", () => {
@@ -75,5 +95,59 @@ describe("computeBufferCapacity", () => {
     expect(computeBufferCapacity(3, BUFFER_BYTE_BUDGETS.default)).toBeGreaterThan(
       computeBufferCapacity(12, BUFFER_BYTE_BUDGETS.default),
     );
+  });
+});
+
+describe("appendChunk", () => {
+  it("appends to a fresh buffer without eviction", () => {
+    const buf = createChunkBuffer(["A", "B"], 100);
+    const positions = makeChunkPositions(2, 10);
+    const timestamps = makeChunkTimestamps(10);
+    appendChunk(buf, positions, timestamps, 10);
+
+    expect(buf.totalTimesteps).toBe(10);
+    expect(buf.bufferStartTimestep).toBe(0);
+    // First slot of first body
+    expect(buf.positions[0]).toBe(0);
+    // Last slot of last body of timestep 9
+    expect(buf.positions[10 * 2 * 6 - 1]).toBe(positions[positions.length - 1]);
+    expect(buf.timestamps[9]).toBe(9n);
+  });
+
+  it("evicts oldest timesteps in chunk-sized blocks when capacity is exceeded", () => {
+    // Capacity 30 = 3 × chunk-of-10. Fourth chunk forces eviction.
+    const buf = createChunkBuffer(["A"], 30);
+    appendChunk(buf, makeChunkPositions(1, 10, 0), makeChunkTimestamps(10, 0n), 10);
+    appendChunk(buf, makeChunkPositions(1, 10, 100), makeChunkTimestamps(10, 100n), 10);
+    appendChunk(buf, makeChunkPositions(1, 10, 200), makeChunkTimestamps(10, 200n), 10);
+    expect(buf.totalTimesteps).toBe(30);
+    expect(buf.bufferStartTimestep).toBe(0);
+
+    // Fourth chunk forces eviction of the first 10 timesteps.
+    appendChunk(buf, makeChunkPositions(1, 10, 300), makeChunkTimestamps(10, 300n), 10);
+    expect(buf.totalTimesteps).toBe(30);
+    expect(buf.bufferStartTimestep).toBe(10);
+
+    // First valid timestep is now what was originally timestep 10 (value 100).
+    expect(buf.timestamps[0]).toBe(100n);
+    expect(buf.positions[0]).toBe(100);
+    // Last valid timestep is the freshly-appended one (300+59).
+    expect(buf.timestamps[29]).toBe(309n);
+  });
+
+  it("returns the number of timesteps shifted (0 if no eviction)", () => {
+    const buf = createChunkBuffer(["A"], 30);
+    expect(
+      appendChunk(buf, makeChunkPositions(1, 10), makeChunkTimestamps(10), 10),
+    ).toBe(0);
+    expect(
+      appendChunk(buf, makeChunkPositions(1, 10), makeChunkTimestamps(10), 10),
+    ).toBe(0);
+    expect(
+      appendChunk(buf, makeChunkPositions(1, 10), makeChunkTimestamps(10), 10),
+    ).toBe(0);
+    expect(
+      appendChunk(buf, makeChunkPositions(1, 10), makeChunkTimestamps(10), 10),
+    ).toBe(10);
   });
 });

--- a/frontend/src/app/store/chunkBuffer.test.ts
+++ b/frontend/src/app/store/chunkBuffer.test.ts
@@ -6,7 +6,10 @@ import {
   selectBufferByteBudget,
   BUFFER_BYTE_BUDGETS,
   appendChunk,
+  readBodyPositionInto,
+  readBodyStateInto,
 } from "./chunkBuffer";
+import * as THREE from "three";
 
 function makeChunkPositions(
   bodyCount: number,
@@ -149,5 +152,43 @@ describe("appendChunk", () => {
     expect(
       appendChunk(buf, makeChunkPositions(1, 10), makeChunkTimestamps(10), 10),
     ).toBe(10);
+  });
+});
+
+describe("readBodyPositionInto", () => {
+  it("reads px/py/pz into the provided Vector3 (no allocation)", () => {
+    const buf = createChunkBuffer(["A", "B"], 10);
+    // Timestep 2, body 1: write known values into the slot.
+    const base = 2 * 2 * 6 + 1 * 6;
+    buf.positions[base + 0] = 100;
+    buf.positions[base + 1] = 200;
+    buf.positions[base + 2] = 300;
+    buf.positions[base + 3] = 0.1; // vx — should be ignored
+    buf.totalTimesteps = 3;
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, 2, 1);
+    expect(out.x).toBe(100);
+    expect(out.y).toBe(200);
+    expect(out.z).toBe(300);
+  });
+});
+
+describe("readBodyStateInto", () => {
+  it("reads position AND velocity into two provided Vector3s", () => {
+    const buf = createChunkBuffer(["A"], 5);
+    buf.positions[0] = 1;
+    buf.positions[1] = 2;
+    buf.positions[2] = 3;
+    buf.positions[3] = 4;
+    buf.positions[4] = 5;
+    buf.positions[5] = 6;
+    buf.totalTimesteps = 1;
+
+    const pos = new THREE.Vector3();
+    const vel = new THREE.Vector3();
+    readBodyStateInto(pos, vel, buf, 0, 0);
+    expect([pos.x, pos.y, pos.z]).toEqual([1, 2, 3]);
+    expect([vel.x, vel.y, vel.z]).toEqual([4, 5, 6]);
   });
 });

--- a/frontend/src/app/store/chunkBuffer.test.ts
+++ b/frontend/src/app/store/chunkBuffer.test.ts
@@ -8,6 +8,8 @@ import {
   appendChunk,
   readBodyPositionInto,
   readBodyStateInto,
+  getTimestamp,
+  getTimestampAsIsoString,
 } from "./chunkBuffer";
 import * as THREE from "three";
 
@@ -23,7 +25,7 @@ function makeChunkPositions(
 
 function makeChunkTimestamps(
   timestepCount: number,
-  startMillis = 0n,
+  startMillis: bigint = BigInt(0),
 ): BigInt64Array {
   const arr = new BigInt64Array(timestepCount);
   for (let i = 0; i < timestepCount; i++) arr[i] = startMillis + BigInt(i);
@@ -64,7 +66,7 @@ describe("selectBufferByteBudget", () => {
   it("returns lowMem budget when deviceMemory ≤ 4", () => {
     const budget = selectBufferByteBudget({
       navigator: { deviceMemory: 4 } as unknown as Navigator,
-      matchMedia: ((_q: string) => ({ matches: false })) as unknown as typeof window.matchMedia,
+      matchMedia: (() => ({ matches: false })) as unknown as typeof window.matchMedia,
     });
     expect(budget).toBe(BUFFER_BYTE_BUDGETS.lowMem);
   });
@@ -72,7 +74,7 @@ describe("selectBufferByteBudget", () => {
   it("returns default budget when neither low-mem signal applies", () => {
     const budget = selectBufferByteBudget({
       navigator: { deviceMemory: 8 } as unknown as Navigator,
-      matchMedia: ((_q: string) => ({ matches: false })) as unknown as typeof window.matchMedia,
+      matchMedia: (() => ({ matches: false })) as unknown as typeof window.matchMedia,
     });
     expect(budget).toBe(BUFFER_BYTE_BUDGETS.default);
   });
@@ -114,28 +116,28 @@ describe("appendChunk", () => {
     expect(buf.positions[0]).toBe(0);
     // Last slot of last body of timestep 9
     expect(buf.positions[10 * 2 * 6 - 1]).toBe(positions[positions.length - 1]);
-    expect(buf.timestamps[9]).toBe(9n);
+    expect(buf.timestamps[9]).toBe(BigInt(9));
   });
 
   it("evicts oldest timesteps in chunk-sized blocks when capacity is exceeded", () => {
     // Capacity 30 = 3 × chunk-of-10. Fourth chunk forces eviction.
     const buf = createChunkBuffer(["A"], 30);
-    appendChunk(buf, makeChunkPositions(1, 10, 0), makeChunkTimestamps(10, 0n), 10);
-    appendChunk(buf, makeChunkPositions(1, 10, 100), makeChunkTimestamps(10, 100n), 10);
-    appendChunk(buf, makeChunkPositions(1, 10, 200), makeChunkTimestamps(10, 200n), 10);
+    appendChunk(buf, makeChunkPositions(1, 10, 0), makeChunkTimestamps(10, BigInt(0)), 10);
+    appendChunk(buf, makeChunkPositions(1, 10, 100), makeChunkTimestamps(10, BigInt(100)), 10);
+    appendChunk(buf, makeChunkPositions(1, 10, 200), makeChunkTimestamps(10, BigInt(200)), 10);
     expect(buf.totalTimesteps).toBe(30);
     expect(buf.bufferStartTimestep).toBe(0);
 
     // Fourth chunk forces eviction of the first 10 timesteps.
-    appendChunk(buf, makeChunkPositions(1, 10, 300), makeChunkTimestamps(10, 300n), 10);
+    appendChunk(buf, makeChunkPositions(1, 10, 300), makeChunkTimestamps(10, BigInt(300)), 10);
     expect(buf.totalTimesteps).toBe(30);
     expect(buf.bufferStartTimestep).toBe(10);
 
     // First valid timestep is now what was originally timestep 10 (value 100).
-    expect(buf.timestamps[0]).toBe(100n);
+    expect(buf.timestamps[0]).toBe(BigInt(100));
     expect(buf.positions[0]).toBe(100);
     // Last valid timestep is the freshly-appended one (300+59).
-    expect(buf.timestamps[29]).toBe(309n);
+    expect(buf.timestamps[29]).toBe(BigInt(309));
   });
 
   it("returns the number of timesteps shifted (0 if no eviction)", () => {
@@ -190,5 +192,25 @@ describe("readBodyStateInto", () => {
     readBodyStateInto(pos, vel, buf, 0, 0);
     expect([pos.x, pos.y, pos.z]).toEqual([1, 2, 3]);
     expect([vel.x, vel.y, vel.z]).toEqual([4, 5, 6]);
+  });
+});
+
+describe("getTimestamp / getTimestampAsIsoString", () => {
+  it("returns raw millis as BigInt and ISO string for a given timestep", () => {
+    const buf = createChunkBuffer(["A"], 5);
+    const millis = BigInt(Date.UTC(2024, 5, 5));
+    buf.timestamps[0] = millis;
+    buf.totalTimesteps = 1;
+
+    expect(getTimestamp(buf, 0)).toBe(millis);
+    expect(getTimestampAsIsoString(buf, 0)).toBe("2024-06-05T00:00:00.000Z");
+  });
+
+  it("returns empty string for out-of-range indices", () => {
+    const buf = createChunkBuffer(["A"], 5);
+    buf.totalTimesteps = 0;
+    expect(getTimestampAsIsoString(buf, 0)).toBe("");
+    expect(getTimestampAsIsoString(buf, -1)).toBe("");
+    expect(getTimestampAsIsoString(buf, 5)).toBe("");
   });
 });

--- a/frontend/src/app/store/chunkBuffer.test.ts
+++ b/frontend/src/app/store/chunkBuffer.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { createChunkBuffer, CHUNK_SIZE } from "./chunkBuffer";
+import {
+  createChunkBuffer,
+  CHUNK_SIZE,
+  computeBufferCapacity,
+  selectBufferByteBudget,
+  BUFFER_BYTE_BUDGETS,
+} from "./chunkBuffer";
 
 describe("createChunkBuffer", () => {
   it("allocates positions and timestamps sized for the given capacity", () => {
@@ -17,5 +23,57 @@ describe("createChunkBuffer", () => {
 
   it("exports CHUNK_SIZE", () => {
     expect(CHUNK_SIZE).toBe(10_000);
+  });
+});
+
+describe("selectBufferByteBudget", () => {
+  it("returns lowMem budget when viewport is narrow", () => {
+    const fakeMatchMedia = (q: string) => ({
+      matches: q.includes("max-width: 767px"),
+    });
+    const budget = selectBufferByteBudget({
+      navigator: undefined,
+      matchMedia: fakeMatchMedia as unknown as typeof window.matchMedia,
+    });
+    expect(budget).toBe(BUFFER_BYTE_BUDGETS.lowMem);
+  });
+
+  it("returns lowMem budget when deviceMemory ≤ 4", () => {
+    const budget = selectBufferByteBudget({
+      navigator: { deviceMemory: 4 } as unknown as Navigator,
+      matchMedia: ((_q: string) => ({ matches: false })) as unknown as typeof window.matchMedia,
+    });
+    expect(budget).toBe(BUFFER_BYTE_BUDGETS.lowMem);
+  });
+
+  it("returns default budget when neither low-mem signal applies", () => {
+    const budget = selectBufferByteBudget({
+      navigator: { deviceMemory: 8 } as unknown as Navigator,
+      matchMedia: ((_q: string) => ({ matches: false })) as unknown as typeof window.matchMedia,
+    });
+    expect(budget).toBe(BUFFER_BYTE_BUDGETS.default);
+  });
+
+  it("returns default budget when navigator/matchMedia are absent (SSR)", () => {
+    const budget = selectBufferByteBudget({
+      navigator: undefined,
+      matchMedia: undefined,
+    });
+    expect(budget).toBe(BUFFER_BYTE_BUDGETS.default);
+  });
+});
+
+describe("computeBufferCapacity", () => {
+  it("derives capacity from byte budget and body count", () => {
+    // 12 MB / (9 bodies × 48 bytes) = 27,962 floor
+    expect(computeBufferCapacity(9, BUFFER_BYTE_BUDGETS.lowMem)).toBe(29_127);
+    // 48 MB / (9 bodies × 48 bytes) = 116,508 floor
+    expect(computeBufferCapacity(9, BUFFER_BYTE_BUDGETS.default)).toBe(116_508);
+  });
+
+  it("scales inversely with body count", () => {
+    expect(computeBufferCapacity(3, BUFFER_BYTE_BUDGETS.default)).toBeGreaterThan(
+      computeBufferCapacity(12, BUFFER_BYTE_BUDGETS.default),
+    );
   });
 });

--- a/frontend/src/app/store/chunkBuffer.ts
+++ b/frontend/src/app/store/chunkBuffer.ts
@@ -79,3 +79,49 @@ export function createChunkBuffer(
     bufferStartTimestep: 0,
   };
 }
+
+/**
+ * Appends a chunk of timesteps to the buffer. If the new data won't fit,
+ * shifts the buffer left by `chunkLen` slots to make room (evicting the
+ * oldest entries) and advances `bufferStartTimestep` accordingly. Returns
+ * the number of timesteps shifted (0 if no eviction occurred).
+ *
+ * `chunkPositions.length` must equal `chunkLen × bodyCount × 6`.
+ * `chunkTimestamps.length` must equal `chunkLen`.
+ */
+export function appendChunk(
+  buffer: ChunkBuffer,
+  chunkPositions: Float64Array,
+  chunkTimestamps: BigInt64Array,
+  chunkLen: number,
+): number {
+  const stride = buffer.bodyCount * 6;
+  let shifted = 0;
+
+  if (buffer.totalTimesteps + chunkLen > buffer.capacity) {
+    // Drop the oldest `chunkLen` timesteps. Assumes chunks are uniformly
+    // sized so a single chunk's worth of eviction always makes room.
+    const dropCount = chunkLen;
+    const surviveCount = buffer.totalTimesteps - dropCount;
+
+    // Shift positions and timestamps left by dropCount slots in place.
+    // copyWithin is a single memmove call — fast even on large arrays.
+    buffer.positions.copyWithin(
+      0,
+      dropCount * stride,
+      (dropCount + surviveCount) * stride,
+    );
+    buffer.timestamps.copyWithin(0, dropCount, dropCount + surviveCount);
+
+    buffer.totalTimesteps = surviveCount;
+    buffer.bufferStartTimestep += dropCount;
+    shifted = dropCount;
+  }
+
+  // Write the new chunk at the current cursor.
+  buffer.positions.set(chunkPositions, buffer.totalTimesteps * stride);
+  buffer.timestamps.set(chunkTimestamps, buffer.totalTimesteps);
+  buffer.totalTimesteps += chunkLen;
+
+  return shifted;
+}

--- a/frontend/src/app/store/chunkBuffer.ts
+++ b/frontend/src/app/store/chunkBuffer.ts
@@ -157,3 +157,16 @@ export function readBodyStateInto(
   outVel.y = buffer.positions[base + 4];
   outVel.z = buffer.positions[base + 5];
 }
+
+export function getTimestamp(buffer: ChunkBuffer, timestepIdx: number): bigint {
+  return buffer.timestamps[timestepIdx];
+}
+
+export function getTimestampAsIsoString(
+  buffer: ChunkBuffer,
+  timestepIdx: number,
+): string {
+  if (timestepIdx < 0 || timestepIdx >= buffer.totalTimesteps) return "";
+  const millis = Number(buffer.timestamps[timestepIdx]);
+  return new Date(millis).toISOString();
+}

--- a/frontend/src/app/store/chunkBuffer.ts
+++ b/frontend/src/app/store/chunkBuffer.ts
@@ -1,3 +1,5 @@
+import type { Vector3 as ThreeVector3 } from "three";
+
 // Typed-array-backed buffer of simulation snapshots. Mirrors the backend's
 // CelestialBodySnapshot layout (6 doubles per body per timestep: px, py, pz,
 // vx, vy, vz) — the same flat layout the wire format ships, so the decode
@@ -124,4 +126,34 @@ export function appendChunk(
   buffer.totalTimesteps += chunkLen;
 
   return shifted;
+}
+
+// Caller provides the output Vector3 — never allocates per call. Designed
+// to be called inside useFrame at FPS rate.
+export function readBodyPositionInto(
+  out: ThreeVector3,
+  buffer: ChunkBuffer,
+  timestepIdx: number,
+  bodyIdx: number,
+): void {
+  const base = timestepIdx * buffer.bodyCount * 6 + bodyIdx * 6;
+  out.x = buffer.positions[base];
+  out.y = buffer.positions[base + 1];
+  out.z = buffer.positions[base + 2];
+}
+
+export function readBodyStateInto(
+  outPos: ThreeVector3,
+  outVel: ThreeVector3,
+  buffer: ChunkBuffer,
+  timestepIdx: number,
+  bodyIdx: number,
+): void {
+  const base = timestepIdx * buffer.bodyCount * 6 + bodyIdx * 6;
+  outPos.x = buffer.positions[base];
+  outPos.y = buffer.positions[base + 1];
+  outPos.z = buffer.positions[base + 2];
+  outVel.x = buffer.positions[base + 3];
+  outVel.y = buffer.positions[base + 4];
+  outVel.z = buffer.positions[base + 5];
 }

--- a/frontend/src/app/store/chunkBuffer.ts
+++ b/frontend/src/app/store/chunkBuffer.ts
@@ -23,6 +23,42 @@ export interface ChunkBuffer {
   bufferStartTimestep: number;
 }
 
+export const BUFFER_BYTE_BUDGETS = {
+  lowMem: 12 * 1024 * 1024, // 12 MB — mobile / low-RAM
+  default: 48 * 1024 * 1024, // 48 MB — desktop / tablet
+} as const;
+
+interface ByteBudgetEnv {
+  navigator: Navigator | undefined;
+  matchMedia: typeof window.matchMedia | undefined;
+}
+
+// `env` is injected so tests can drive the branches without globals.
+// Default reads window/navigator if present (handles SSR + node-test env).
+export function selectBufferByteBudget(env?: ByteBudgetEnv): number {
+  const e: ByteBudgetEnv = env ?? {
+    navigator: typeof navigator !== "undefined" ? navigator : undefined,
+    matchMedia: typeof window !== "undefined" ? window.matchMedia : undefined,
+  };
+  const dm =
+    e.navigator !== undefined && "deviceMemory" in e.navigator
+      ? ((e.navigator as Navigator & { deviceMemory?: number }).deviceMemory ?? Infinity)
+      : Infinity;
+  const isLowMem = dm <= 4;
+  const isNarrow =
+    e.matchMedia !== undefined && e.matchMedia("(max-width: 767px)").matches;
+  return isLowMem || isNarrow
+    ? BUFFER_BYTE_BUDGETS.lowMem
+    : BUFFER_BYTE_BUDGETS.default;
+}
+
+export function computeBufferCapacity(
+  bodyCount: number,
+  byteBudget: number,
+): number {
+  return Math.floor(byteBudget / (bodyCount * BYTES_PER_TIMESTEP_PER_BODY));
+}
+
 export function createChunkBuffer(
   bodyNames: readonly string[],
   capacity: number,

--- a/frontend/src/app/store/chunkBuffer.ts
+++ b/frontend/src/app/store/chunkBuffer.ts
@@ -1,0 +1,45 @@
+// Typed-array-backed buffer of simulation snapshots. Mirrors the backend's
+// CelestialBodySnapshot layout (6 doubles per body per timestep: px, py, pz,
+// vx, vy, vz) — the same flat layout the wire format ships, so the decode
+// worker can write directly into this with no intermediate JS-object hops.
+//
+// Lookup is O(1) by timestep index, eliminating the Object.keys() / map.find
+// hot-path costs of the previous date-keyed object representation.
+
+export const CHUNK_SIZE = 10_000;
+export const BYTES_PER_TIMESTEP_PER_BODY = 6 * 8; // 6 doubles
+
+export interface ChunkBuffer {
+  positions: Float64Array;
+  timestamps: BigInt64Array;
+  bodyNames: readonly string[];
+  bodyNameToIndex: ReadonlyMap<string, number>;
+  bodyCount: number;
+  capacity: number;
+  // Number of valid timesteps currently in the buffer. Write cursor.
+  totalTimesteps: number;
+  // Where the kept window starts in the session's global timestep numbering.
+  // Advances by CHUNK_SIZE every eviction.
+  bufferStartTimestep: number;
+}
+
+export function createChunkBuffer(
+  bodyNames: readonly string[],
+  capacity: number,
+): ChunkBuffer {
+  const bodyCount = bodyNames.length;
+  const map = new Map<string, number>();
+  for (let i = 0; i < bodyNames.length; i++) {
+    map.set(bodyNames[i], i);
+  }
+  return {
+    positions: new Float64Array(capacity * bodyCount * 6),
+    timestamps: new BigInt64Array(capacity),
+    bodyNames,
+    bodyNameToIndex: map,
+    bodyCount,
+    capacity,
+    totalTimesteps: 0,
+    bufferStartTimestep: 0,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 2 of the [data buffering pipeline redesign](docs/superpowers/specs/2026-05-14-data-buffering-pipeline-redesign.md). Builds the typed-array `ChunkBuffer` module in isolation with full Vitest coverage.

**No Redux wiring yet — nothing consumes this module.** Phase 3 will swap `simulationData` for `chunkBuffer` in the slice and decoder. This PR is purely additive; the running app is unchanged.

## What's included

- `frontend/src/app/store/chunkBuffer.ts` — the new module
- `frontend/src/app/store/chunkBuffer.test.ts` — 15 tests pinning the contract

### Module surface

| Export | Purpose |
|---|---|
| `ChunkBuffer` type + `createChunkBuffer(bodyNames, capacity)` | Flat-Float64-backed buffer mirroring the wire format layout (`idx × bodyCount × 6` doubles per timestep, components `[px, py, pz, vx, vy, vz]`). Includes `bodyNameToIndex` map so consumers stop doing per-frame `.find()`. |
| `BUFFER_BYTE_BUDGETS` + `selectBufferByteBudget(env?)` | 12 MB (mobile / low-RAM) and 48 MB (desktop) tiers. Env-injected for testability; uses `navigator.deviceMemory` and `matchMedia` heuristics at runtime. |
| `computeBufferCapacity(bodyCount, byteBudget)` | `floor(byteBudget / (bodyCount × 48))`. Scales inversely with body count. |
| `appendChunk(buffer, positions, timestamps, chunkLen)` | Writes a new chunk at the cursor; `copyWithin`-based eviction when capacity is exceeded. Returns shift count so slice can adjust `currentTimeStepIndex`. |
| `readBodyPositionInto(out, buffer, t, b)` / `readBodyStateInto(outPos, outVel, buffer, t, b)` | Zero-allocation accessors for the render loop. Caller provides scratch `THREE.Vector3`. |
| `getTimestamp(buffer, t)` / `getTimestampAsIsoString(buffer, t)` | Replaces `selectCurrentTimeStepKey`. Empty string on out-of-range so consumers early-return cleanly. |

## Test plan

- [x] `cd frontend && npx vitest run src/app/store/chunkBuffer.test.ts` — 15/15 pass.
- [x] `cd frontend && npm test` — 95/95 pass (full suite).
- [x] `cd frontend && npm run build` — passes.
- [x] `cd frontend && npm run lint` — clean of new code (2 pre-existing warnings remain in unrelated files).
- [x] `npx tsc --noEmit` — no new errors introduced (1 pre-existing error in `userActionLogger.test.ts` on master, untouched).

No browser smoke test — this module isn't wired into the app yet. Phase 3 lands that integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)