### PR TITLE
Buffering pipeline follow-ups: middleware threshold tests + ARCHITECTURE.md refresh

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,11 +19,11 @@ End-to-end hosted simulation. A user picks bodies, frame, integrator, and time s
    Vercel (planned)                                      Fly.io (planned)
 ```
 
-**Backend** — Spring Boot 3 + Orekit 12. `POST /api/simulation/initialize` builds a session with bodies, frame, integrator, and start date; subsequent `POST /api/simulation/chunk` calls run simulation chunks of N steps and return results as zstd-compressed binary. Sessions are tracked by sessionID and evicted by a periodic idle-timeout sweeper.
+**Backend** — Spring Boot 3 + Orekit 12. `POST /api/simulation/initialize` builds a session with bodies, frame, integrator, and start date; subsequent `POST /api/simulation/chunk` calls return zstd-compressed binary trajectories. After each chunk is served, the next 10k-step block is speculatively pre-computed on a daemon executor so subsequent requests hit cache. Sessions are tracked by sessionID and evicted by a periodic idle-timeout sweeper.
 
-**Frontend** — Next.js + React Three Fiber. Redux Toolkit holds the buffered timestep map; an async thunk fetches the next chunk when the buffer dips below threshold and discards old chunks at a configured cap. The render loop tape-plays the buffer at a target frame rate via R3F's `useFrame`; the scene supports two scale presets (semi-realistic, realistic) and per-body exception scaling for tightly-coupled pairs (e.g., Earth–Moon).
+**Frontend** — Next.js + React Three Fiber. Redux Toolkit holds a typed-array-backed chunk buffer (`Float64Array` positions + `BigInt64Array` timestamps) laid out in the same row-major shape as the wire format — O(1) lookup by timestep index, zero-copy hand-off from the decode worker. An async thunk fetches the next chunk when the buffer dips below a speed-aware threshold (`max(1000, speedMultiplier × FPS × rolling-fetch-latency × 1.5)`), and `copyWithin`-shifts the oldest entries left when capacity is reached. Capacity is byte-budget-derived at session start (12 MB mobile / 48 MB desktop) so it scales inversely with body count. The render loop tape-plays the buffer at a target frame rate via R3F's `useFrame`; the scene supports two scale presets (semi-realistic, realistic) and per-body exception scaling for tightly-coupled pairs (e.g., Earth–Moon).
 
-**Wire format** — custom little-endian binary layout: body names + µ in a one-time header, then per-timestep `int64` timestamp + 6 `float64` per body (position + velocity). Zstd-compressed with a 4-byte little-endian uncompressed-size prefix. Decoded client-side in a Web Worker so the main thread stays unblocked during chunk arrivals.
+**Wire format** — custom little-endian binary layout: body names + µ in a one-time header, then per-timestep `int64` timestamp + 6 `float64` per body (position + velocity). Zstd-compressed with a 4-byte little-endian uncompressed-size prefix. The Web Worker decodes directly into the `Float64Array` + `BigInt64Array` shape the buffer expects and transfers both underlying buffers back to the main thread — no intermediate JS-object hops, no copy at the worker boundary.
 
 ## Architecture decisions
 
@@ -43,11 +43,23 @@ Backend snapshots are always emitted Sun-relative — `Simulation.snapshotFromSt
 
 ### Imperative scene graph, no per-tick React rerenders
 
-The 3D scene's R3F components (`Sphere`, `Trail`, `Reticle`, `GhostLabel`, `Camera`) update positions imperatively inside `useFrame` by reading the live snapshot from Redux via `useStore.getState()` — they never subscribe to per-frame state. Per-frame Redux subscriptions would force React to reconcile the entire scene on every animation tick, which dominated the cost in earlier profiles. Pattern documented in `engineering_patterns_spacesim.md`. Active body identity carries as a string (`activeBodyName`), not the full snapshot, so identity changes don't cascade.
+The 3D scene's R3F components (`Sphere`, `Trail`, `Reticle`, `GhostLabel`, `Camera`) update positions imperatively inside `useFrame` by reading from the chunk buffer at the current timestep via `useStore.getState()` — they never subscribe to per-frame state. Per-frame Redux subscriptions would force React to reconcile the entire scene on every animation tick, which dominated the cost in earlier profiles. Pattern documented in `engineering_patterns_spacesim.md`. Active body identity carries as a string (`activeBodyName`), not a buffer reference, so identity changes don't cascade.
 
 ### Hot-path mutating-output pattern
 
 Anything in the frontend render loop or backend integrator step uses pre-allocated buffers and mutating-output APIs (`scaleDistanceInto`, `subtractInto`, `derivativesInto`, `stepInto`, etc.) to avoid per-frame allocation. Documented in `engineering_patterns_spacesim.md`. The Trail.tsx perf bug — closures + per-frame `Array.find()` summing to ~45 000 closure allocations per frame at trail length 5000 — was the motivating incident.
+
+### Typed-array buffer mirrors the wire format end-to-end
+
+The chunk buffer is a flat `Float64Array` of position+velocity (`idx × bodyCount × 6` doubles per timestep, components `[px, py, pz, vx, vy, vz]`) paired with a `BigInt64Array` of millis-since-epoch timestamps. Identical layout on the wire, in the decode worker, and in Redux state. Consumers (`Sphere`, `Trail`, `Reticle`, etc.) resolve `bodyName → index` once per session via a `Map` and read state at `(timestep, body)` via mutating accessors (`readBodyPositionInto`, `readBodyStateInto`) into pre-allocated scratch `THREE.Vector3` refs. The previous architecture was a date-keyed `Record<string, CelestialBody[]>` — every per-frame lookup paid `Object.keys()` (O(N) in buffer size) and every body access paid `.find()` (O(N) in body count), so buffer-size and consumer-count both fed the per-frame cost. The typed-array layout decouples them; per-frame cost is now O(1) regardless of buffer depth. **Trade-offs:** Immer doesn't draft typed arrays (so the slice keeps the same wrapper object reference across appends — `appendChunk` mutates in place); selectors that need to fire on chunk-arrival depend on `totalTimesteps` rather than buffer-reference identity. Chunk transitions are silent — no auto-unpause on arrival, no "Fetching data" modal flash between chunks.
+
+### Speculative precompute + speed-aware prefetch
+
+Backend kicks off the next 10k-step compute the moment it ships a chunk, holding the result in a per-session `CompletableFuture<byte[]>` cache. Client-side, the prefetch trigger scales with `speedMultiplier × FPS × rolling-fetch-latency × safety_factor` — so at `speedMultiplier=128` the threshold becomes ~11 520 steps and a fetch is essentially always in flight. The two pieces work together: the server-side cache cuts perceived chunk-fetch latency to near-network-only, and the speed-aware threshold ensures the client requests early enough that the cache hit lands before the buffer empties. Buffer eviction is `Float64Array.copyWithin` (single memmove), one-shot on overflow.
+
+### Buffer capacity is byte-budgeted, not step-counted
+
+Two device-class tiers picked at session start: 12 MB (mobile / `deviceMemory ≤ 4` / viewport `< 768px`) and 48 MB (everything else). Capacity falls out as `floor(byteBudget / (bodyCount × 48))`, so a 3-body sim gets a much deeper buffer than a 12-body sim under the same budget. Decoupling the cap from a fixed timestep count means user-driven body-count changes don't accidentally exceed the memory budget; decoupling from device class means mobile won't try to allocate ~43 MB on a phone. Heuristic ceilings, not measured — validation path is in the redesign spec.
 
 ## Resolved design decisions (UI redesign)
 

--- a/frontend/src/app/store/slices/SimulationSlice.middleware.test.ts
+++ b/frontend/src/app/store/slices/SimulationSlice.middleware.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { configureStore } from "@reduxjs/toolkit";
+import simulationReducer, {
+  simulationUpdateDataMiddleware,
+  setCurrentTimeStepIndex,
+  loadSimulation,
+  appendChunkToBuffer,
+  setSpeedMultiplier,
+  type SimulationParameters,
+} from "./SimulationSlice";
+import requestReducer, {
+  recordFetchLatency,
+  setRequestInProgress,
+} from "./RequestSlice";
+import SimConstants from "@/app/constants/SimConstants";
+
+// Mock the request thunk so the middleware's dispatchChunkRequest becomes
+// an observable spy. The middleware imports dispatchChunkRequest from the
+// real module at load time, so the mock has to be hoisted (vi.mock is).
+vi.mock("@/app/store/middleware/simulationRequestThunk", () => ({
+  dispatchChunkRequest: vi.fn(),
+}));
+
+import { dispatchChunkRequest } from "@/app/store/middleware/simulationRequestThunk";
+
+// Middleware threshold contract (matches the slice's formula):
+//
+//   threshold = max(1000, ceil(speedMultiplier * FPS * fetchLatencyMs/1000 * 1.5))
+//
+// Prefetch fires when `remaining <= threshold && !isRequestInProgress`.
+// Tests pin the formula at the boundary conditions for each playback regime.
+
+function buildStore() {
+  return configureStore({
+    reducer: {
+      simulation: simulationReducer,
+      request: requestReducer,
+    },
+    middleware: (getDefault) =>
+      getDefault({ serializableCheck: false }).concat(
+        simulationUpdateDataMiddleware,
+      ),
+  });
+}
+
+function seedSession(
+  store: ReturnType<typeof buildStore>,
+  totalTimesteps: number,
+) {
+  const params: SimulationParameters = {
+    celestialBodyPropertiesList: [{ name: "Sun" }],
+    simulationMetaData: { sessionID: "TEST_SESSION" },
+    lastRequest: null,
+    showGrid: true,
+    showAxes: false,
+    showPlanetInfoOverlay: true,
+    showTrails: true,
+    showOrbitPaths: true,
+    simulationScale: SimConstants.SCALE.SEMI_REALISTIC,
+    cameraPreset: "top-down",
+    displayFrame: "helio",
+  };
+  store.dispatch(loadSimulation(params));
+  store.dispatch(
+    appendChunkToBuffer({
+      bodyNames: ["Sun"],
+      bodyCount: 1,
+      timestepCount: totalTimesteps,
+      positions: new Float64Array(totalTimesteps * 6),
+      timestamps: new BigInt64Array(totalTimesteps),
+      mu: { Sun: 1 },
+    }),
+  );
+}
+
+describe("simulationUpdateDataMiddleware — speed-aware prefetch threshold", () => {
+  beforeEach(() => {
+    vi.mocked(dispatchChunkRequest).mockClear();
+  });
+
+  it("speed=1, default EMA: formula yields 90, MIN_THRESHOLD=1000 clamps → fires at remaining≤1000", () => {
+    const store = buildStore();
+    seedSession(store, 100_000);
+    // Remaining = 100_000 - 99_000 = 1000 → threshold reached.
+    store.dispatch(setCurrentTimeStepIndex(99_000));
+    expect(dispatchChunkRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("speed=1, default EMA: does NOT fire at remaining=1001", () => {
+    const store = buildStore();
+    seedSession(store, 100_000);
+    // Remaining = 100_000 - 98_999 = 1001 → above threshold.
+    store.dispatch(setCurrentTimeStepIndex(98_999));
+    expect(dispatchChunkRequest).not.toHaveBeenCalled();
+  });
+
+  it("speed=128, default EMA: threshold scales to 11520 (128 × 60 × 1.0 × 1.5)", () => {
+    const store = buildStore();
+    seedSession(store, 100_000);
+    // 1 → 2 → 4 → 8 → 16 → 32 → 64 → 128 (seven "increase" dispatches).
+    for (let i = 0; i < 7; i++) store.dispatch(setSpeedMultiplier("increase"));
+
+    // Remaining = 100_000 - 88_480 = 11_520 → threshold reached at speed=128.
+    store.dispatch(setCurrentTimeStepIndex(88_480));
+    expect(dispatchChunkRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("speed=128, default EMA: does NOT fire at remaining=11521", () => {
+    const store = buildStore();
+    seedSession(store, 100_000);
+    for (let i = 0; i < 7; i++) store.dispatch(setSpeedMultiplier("increase"));
+
+    store.dispatch(setCurrentTimeStepIndex(88_479));
+    expect(dispatchChunkRequest).not.toHaveBeenCalled();
+  });
+
+  it("threshold reacts to fetch-latency EMA (2× latency → 2× formula)", () => {
+    const store = buildStore();
+    seedSession(store, 100_000);
+    // Drive EMA upward by a couple of "slow" samples.
+    // EMA starts at 1000. α=0.3.
+    // After recordFetchLatency(5000): 0.7*1000 + 0.3*5000 = 2200.
+    // After recordFetchLatency(5000): 0.7*2200 + 0.3*5000 = 3040.
+    store.dispatch(recordFetchLatency(5000));
+    store.dispatch(recordFetchLatency(5000));
+
+    // At speed=32, EMA=3040ms: 32 × 60 × (3040/1000) × 1.5 = 8755.2 → ceil = 8756.
+    for (let i = 0; i < 5; i++) store.dispatch(setSpeedMultiplier("increase"));
+
+    // Remaining = 100_000 - 91_244 = 8756 → fires.
+    store.dispatch(setCurrentTimeStepIndex(91_244));
+    expect(dispatchChunkRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire when isRequestInProgress=true (even if remaining is below threshold)", () => {
+    const store = buildStore();
+    seedSession(store, 100_000);
+    store.dispatch(setRequestInProgress(true));
+
+    store.dispatch(setCurrentTimeStepIndex(99_000));
+    expect(dispatchChunkRequest).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire when buffer is null (pre-session)", () => {
+    const store = buildStore();
+    // No seedSession — chunkBuffer is null.
+    store.dispatch(setCurrentTimeStepIndex(99_000));
+    expect(dispatchChunkRequest).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Two small follow-ups to the buffering pipeline redesign series:

- **`SimulationSlice.middleware.test.ts`** — 7 tests pinning the speed-aware prefetch threshold formula at boundary conditions. Covers speed=1 (MIN_THRESHOLD clamps), speed=128 (full formula scales to ~11.5k steps), EMA-driven threshold scaling, the `isRequestInProgress` short-circuit, and the pre-session null-buffer guard. Test-by-formula, not by behaviour — so any future drift in the formula constants (alpha, MIN_THRESHOLD, SAFETY_FACTOR) fails loudly.
- **`ARCHITECTURE.md`** — replaces the old "Redux Toolkit holds the buffered timestep map" description with the typed-array buffer / byte-budget capacity / speculative precompute / speed-aware prefetch story. Adds three new entries under `## Architecture decisions`: the typed-array buffer end-to-end shape, speculative precompute + speed-aware prefetch as a pair, and byte-budget capacity tiering. Also fixes a stale "live snapshot" reference under the imperative scene-graph section.

## Test plan

- [x] `cd frontend && npm test` — 107/107 pass (was 100 before this PR; +7 new threshold tests).
- [x] `cd frontend && npx vitest run src/app/store/slices/SimulationSlice.middleware.test.ts` — 7/7 green in isolation.
- [x] Doc-only changes for ARCHITECTURE.md; no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)