### PR TITLE
Hermite Phase 1: cubic interpolation + wall-clock-rate animation

### DIFF
--- a/docs/superpowers/plans/2026-05-15-hermite-phase-1-frontend-interpolation.md
+++ b/docs/superpowers/plans/2026-05-15-hermite-phase-1-frontend-interpolation.md
@@ -1,0 +1,999 @@
+# Hermite Phase 1: Frontend Interpolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add cubic Hermite interpolation to chunkBuffer's read functions and switch AnimationController to wall-clock-rate float-index driving, producing visually smoother playback between integration samples without any wire-format change.
+
+**Architecture:** Widen the existing `readBodyPositionInto` and `readBodyStateInto` to accept a float `floatIdx`. At integer values, short-circuit to the existing direct typed-array read (zero perf cost — Trail's tail loop and any other integer caller is unaffected). At fractional values, perform inline cubic Hermite using the surrounding two keyframes' positions, velocities, and timestamps. Switch AnimationController from integer-step throttled motion to wall-clock-rate float motion (`delta · FPS · speedMultiplier`), which makes the slice's `currentTimeStepIndex` naturally fractional and propagates through every consumer transparently.
+
+**Tech Stack:** TypeScript, Vitest (frontend tests), React Three Fiber (`useFrame`), Redux Toolkit, Three.js Vector3.
+
+**Spec:** `docs/superpowers/specs/2026-05-15-hermite-keyframe-interpolation-design.md`
+
+**Branch:** `hermite-frontend` (branch from master once `hermite-spec` merges, OR branch from `hermite-spec` if proceeding before spec merge — confirm with byeon).
+
+---
+
+## File structure
+
+| File | Role | Action |
+|---|---|---|
+| `frontend/src/app/store/chunkBuffer.ts` | Hermite math + widened read functions | Modify (lines 141-167) |
+| `frontend/src/app/store/chunkBuffer.test.ts` | Hermite tests | Modify (extend existing test file) |
+| `frontend/src/app/components/scene/AnimationController.tsx` | Wall-clock-rate float driving + drop useSelector subscription | Modify (full rewrite of useFrame body) |
+| `frontend/src/app/utils/animationStep.ts` | Pure helper for next-index math (extracted for unit-testability) | Create |
+| `frontend/src/app/utils/animationStep.test.ts` | Tests for the helper | Create |
+| `frontend/src/app/components/scene/Camera.tsx` | Hoist per-frame Vector3 allocation (opportunistic, per render-loop rules) | Modify |
+
+No other files require changes — every other consumer (`Sphere`, `Trail`, `OrbitPath`, `Reticle`, `GhostLabel`, `BodyCard`, `framePivot`) already passes `currentTimeStepIndex` straight through to the read functions.
+
+---
+
+## Task 1: Regression test for existing integer-index read behavior
+
+**Why first:** Locks in current behavior before changing the implementation, so the s=0 fast path is provably preserved.
+
+**Files:**
+- Modify: `frontend/src/app/store/chunkBuffer.test.ts` (add new `describe` block)
+
+- [ ] **Step 1: Add a regression `describe` block for `readBodyPositionInto` integer reads.**
+
+Append after the existing tests in `chunkBuffer.test.ts`:
+
+```ts
+describe("readBodyPositionInto — integer index (regression)", () => {
+  it("returns stored position exactly at integer keyframe", () => {
+    const buf = createChunkBuffer(["Earth"], 4);
+    // Keyframe 0: pos=(1,2,3) vel=(10,11,12)
+    // Keyframe 1: pos=(4,5,6) vel=(13,14,15)
+    const positions = new Float64Array([
+      1, 2, 3, 10, 11, 12,
+      4, 5, 6, 13, 14, 15,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, 0, 0);
+    expect(out.x).toBe(1);
+    expect(out.y).toBe(2);
+    expect(out.z).toBe(3);
+
+    readBodyPositionInto(out, buf, 1, 0);
+    expect(out.x).toBe(4);
+    expect(out.y).toBe(5);
+    expect(out.z).toBe(6);
+  });
+});
+
+describe("readBodyStateInto — integer index (regression)", () => {
+  it("returns stored position and velocity exactly at integer keyframe", () => {
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      1, 2, 3, 10, 11, 12,
+      4, 5, 6, 13, 14, 15,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const outPos = new THREE.Vector3();
+    const outVel = new THREE.Vector3();
+    readBodyStateInto(outPos, outVel, buf, 1, 0);
+    expect(outPos.x).toBe(4);
+    expect(outPos.y).toBe(5);
+    expect(outPos.z).toBe(6);
+    expect(outVel.x).toBe(13);
+    expect(outVel.y).toBe(14);
+    expect(outVel.z).toBe(15);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests, verify they pass against current code.**
+
+Run from repo root:
+```bash
+cd frontend && npm test -- chunkBuffer.test.ts
+```
+
+Expected: both new tests pass alongside existing tests.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add frontend/src/app/store/chunkBuffer.test.ts
+git commit -m "test(chunkBuffer): regression tests for integer-index reads
+
+Locks in the s=0 fast path behavior before adding Hermite interpolation
+in subsequent commits."
+```
+
+---
+
+## Task 2: Failing test for fractional Hermite — position
+
+**Files:**
+- Modify: `frontend/src/app/store/chunkBuffer.test.ts`
+
+- [ ] **Step 1: Add the failing fractional-position test.**
+
+Append after the regression `describe` blocks:
+
+```ts
+describe("readBodyPositionInto — fractional index (Hermite)", () => {
+  it("interpolates position at midpoint via cubic Hermite", () => {
+    // Two keyframes 1 second apart. Pick a motion where Hermite gives a
+    // known analytical answer: constant velocity (linear motion).
+    // p0=(0,0,0), v0=(1,0,0), p1=(1,0,0), v1=(1,0,0), dt=1s.
+    // Linear motion → midpoint exactly (0.5, 0, 0).
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      0, 0, 0, 1, 0, 0,
+      1, 0, 0, 1, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]); // 1 second apart
+    appendChunk(buf, positions, timestamps, 2);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, 0.5, 0);
+    expect(out.x).toBeCloseTo(0.5, 10);
+    expect(out.y).toBeCloseTo(0, 10);
+    expect(out.z).toBeCloseTo(0, 10);
+  });
+
+  it("interpolates non-linear motion correctly via Hermite cubic", () => {
+    // Different start + end velocities → cubic curves through both endpoints.
+    // p0=(0,0,0), v0=(0,0,0), p1=(1,0,0), v1=(0,0,0), dt=1s.
+    // Hermite with zero tangents at both ends → smoothstep, midpoint = 0.5.
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      0, 0, 0, 0, 0, 0,
+      1, 0, 0, 0, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, 0.5, 0);
+    // Hermite basis at s=0.5 with zero tangents: h00=0.5, h01=0.5
+    // p(0.5) = 0.5·p0 + 0.5·p1 = 0.5·1 = 0.5
+    expect(out.x).toBeCloseTo(0.5, 10);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify the new tests fail.**
+
+```bash
+cd frontend && npm test -- chunkBuffer.test.ts
+```
+
+Expected: existing tests pass; the two new fractional tests **fail** because current `readBodyPositionInto` does `out.x = buffer.positions[base]` with `base = Math.floor(0.5) * stride + ...` — it'll silently floor to keyframe 0, returning (0,0,0) instead of (0.5,0,0).
+
+---
+
+## Task 3: Implement Hermite for `readBodyPositionInto`
+
+**Files:**
+- Modify: `frontend/src/app/store/chunkBuffer.ts:141-151`
+
+- [ ] **Step 1: Replace `readBodyPositionInto` with the widened, Hermite-aware version.**
+
+Find the existing function (around line 141):
+
+```ts
+// Caller provides the output Vector3 — never allocates per call. Designed
+// to be called inside useFrame at FPS rate.
+export function readBodyPositionInto(
+  out: ThreeVector3,
+  buffer: ChunkBuffer,
+  timestepIdx: number,
+  bodyIdx: number,
+): void {
+  const base = timestepIdx * buffer.bodyCount * 6 + bodyIdx * 6;
+  out.x = buffer.positions[base];
+  out.y = buffer.positions[base + 1];
+  out.z = buffer.positions[base + 2];
+}
+```
+
+Replace with:
+
+```ts
+// Caller provides the output Vector3 — never allocates per call. Designed
+// to be called inside useFrame at FPS rate.
+//
+// floatIdx ∈ [0, totalTimesteps - 1]. Integer values short-circuit to a
+// direct typed-array read (zero perf cost; preserves existing s=0 behavior
+// for callers like Trail's tail loop). Fractional values invoke cubic
+// Hermite between floor(floatIdx) and floor(floatIdx) + 1, using the stored
+// velocities as exact tangents and per-keyframe timestamps for the interval.
+export function readBodyPositionInto(
+  out: ThreeVector3,
+  buffer: ChunkBuffer,
+  floatIdx: number,
+  bodyIdx: number,
+): void {
+  // Boundary clamp: at or past last keyframe → exact last-keyframe read.
+  // Before first keyframe → exact first-keyframe read. Single-keyframe
+  // buffer (totalTimesteps === 1) also lands here.
+  if (floatIdx <= 0 || buffer.totalTimesteps <= 1) {
+    const base = 0 * buffer.bodyCount * 6 + bodyIdx * 6;
+    out.x = buffer.positions[base];
+    out.y = buffer.positions[base + 1];
+    out.z = buffer.positions[base + 2];
+    return;
+  }
+  if (floatIdx >= buffer.totalTimesteps - 1) {
+    const base =
+      (buffer.totalTimesteps - 1) * buffer.bodyCount * 6 + bodyIdx * 6;
+    out.x = buffer.positions[base];
+    out.y = buffer.positions[base + 1];
+    out.z = buffer.positions[base + 2];
+    return;
+  }
+
+  const i0 = Math.floor(floatIdx);
+  const s = floatIdx - i0;
+
+  // Fast path: exactly on a keyframe. Single typed-array read, no Hermite.
+  if (s === 0) {
+    const base = i0 * buffer.bodyCount * 6 + bodyIdx * 6;
+    out.x = buffer.positions[base];
+    out.y = buffer.positions[base + 1];
+    out.z = buffer.positions[base + 2];
+    return;
+  }
+
+  // Hermite path. Compute basis once.
+  const stride = buffer.bodyCount * 6;
+  const base0 = i0 * stride + bodyIdx * 6;
+  const base1 = base0 + stride;
+
+  const dtMs = Number(buffer.timestamps[i0 + 1] - buffer.timestamps[i0]);
+  const dt = dtMs / 1000; // velocities are m/s; convert ms → s
+
+  const s2 = s * s;
+  const s3 = s2 * s;
+  const h00 = 2 * s3 - 3 * s2 + 1;
+  const h10 = s3 - 2 * s2 + s;
+  const h01 = -2 * s3 + 3 * s2;
+  const h11 = s3 - s2;
+
+  // Per-axis Hermite. Velocities live at base+3..+5.
+  const p0x = buffer.positions[base0];
+  const p0y = buffer.positions[base0 + 1];
+  const p0z = buffer.positions[base0 + 2];
+  const v0x = buffer.positions[base0 + 3];
+  const v0y = buffer.positions[base0 + 4];
+  const v0z = buffer.positions[base0 + 5];
+  const p1x = buffer.positions[base1];
+  const p1y = buffer.positions[base1 + 1];
+  const p1z = buffer.positions[base1 + 2];
+  const v1x = buffer.positions[base1 + 3];
+  const v1y = buffer.positions[base1 + 4];
+  const v1z = buffer.positions[base1 + 5];
+
+  out.x = h00 * p0x + h10 * dt * v0x + h01 * p1x + h11 * dt * v1x;
+  out.y = h00 * p0y + h10 * dt * v0y + h01 * p1y + h11 * dt * v1y;
+  out.z = h00 * p0z + h10 * dt * v0z + h01 * p1z + h11 * dt * v1z;
+}
+```
+
+- [ ] **Step 2: Run all chunkBuffer tests, verify they pass.**
+
+```bash
+cd frontend && npm test -- chunkBuffer.test.ts
+```
+
+Expected: all tests pass — regression tests still green, new fractional tests now green.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add frontend/src/app/store/chunkBuffer.ts frontend/src/app/store/chunkBuffer.test.ts
+git commit -m "feat(chunkBuffer): cubic Hermite interpolation in readBodyPositionInto
+
+Widens the existing function to accept float idx. Integer values use the
+existing direct read (zero perf cost). Fractional values perform inline
+cubic Hermite using stored velocities as tangents and per-keyframe
+timestamps for the interval — no allocations, same caller-provided
+scratch pattern."
+```
+
+---
+
+## Task 4: Hermite for `readBodyStateInto` (position + velocity)
+
+**Files:**
+- Modify: `frontend/src/app/store/chunkBuffer.ts:153-167`
+- Modify: `frontend/src/app/store/chunkBuffer.test.ts`
+
+- [ ] **Step 1: Add the failing fractional-state test.**
+
+Append to `chunkBuffer.test.ts`:
+
+```ts
+describe("readBodyStateInto — fractional index (Hermite)", () => {
+  it("interpolates position and velocity at midpoint via Hermite", () => {
+    // Constant velocity → linear position, constant velocity at all s.
+    // p0=(0,0,0), v0=(1,0,0), p1=(1,0,0), v1=(1,0,0), dt=1s.
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      0, 0, 0, 1, 0, 0,
+      1, 0, 0, 1, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const outPos = new THREE.Vector3();
+    const outVel = new THREE.Vector3();
+    readBodyStateInto(outPos, outVel, buf, 0.5, 0);
+    expect(outPos.x).toBeCloseTo(0.5, 10);
+    expect(outVel.x).toBeCloseTo(1, 10); // constant-velocity case
+  });
+
+  it("interpolates velocity correctly when endpoints differ", () => {
+    // p0=(0,0,0), v0=(0,0,0), p1=(1,0,0), v1=(0,0,0), dt=1s.
+    // Smoothstep position. Velocity at s=0.5 = derivative of smoothstep
+    // wrt sim-time = (h00'·p0 + h01'·p1)/dt + h10'·v0 + h11'·v1.
+    // h00'(0.5) = 6·0.5² - 6·0.5 = -1.5
+    // h01'(0.5) = -6·0.5² + 6·0.5 =  1.5
+    // h10'(0.5) = 3·0.5² - 4·0.5 + 1 = 0.75 - 2 + 1 = -0.25
+    // h11'(0.5) = 3·0.5² - 2·0.5 = 0.75 - 1 = -0.25
+    // velocity = (-1.5·0 + 1.5·1)/1 + -0.25·0 + -0.25·0 = 1.5 m/s
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      0, 0, 0, 0, 0, 0,
+      1, 0, 0, 0, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const outPos = new THREE.Vector3();
+    const outVel = new THREE.Vector3();
+    readBodyStateInto(outPos, outVel, buf, 0.5, 0);
+    expect(outVel.x).toBeCloseTo(1.5, 10);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify the new state tests fail.**
+
+```bash
+cd frontend && npm test -- chunkBuffer.test.ts
+```
+
+Expected: new tests fail (current code returns floored-keyframe state, no interpolation).
+
+- [ ] **Step 3: Replace `readBodyStateInto` with the widened version.**
+
+Find the existing function (around line 153):
+
+```ts
+export function readBodyStateInto(
+  outPos: ThreeVector3,
+  outVel: ThreeVector3,
+  buffer: ChunkBuffer,
+  timestepIdx: number,
+  bodyIdx: number,
+): void {
+  const base = timestepIdx * buffer.bodyCount * 6 + bodyIdx * 6;
+  outPos.x = buffer.positions[base];
+  outPos.y = buffer.positions[base + 1];
+  outPos.z = buffer.positions[base + 2];
+  outVel.x = buffer.positions[base + 3];
+  outVel.y = buffer.positions[base + 4];
+  outVel.z = buffer.positions[base + 5];
+}
+```
+
+Replace with:
+
+```ts
+// Caller provides both output Vector3s — never allocates per call.
+//
+// floatIdx ∈ [0, totalTimesteps - 1]. Integer values short-circuit to
+// direct typed-array reads. Fractional values perform cubic Hermite for
+// position (using stored velocities as tangents) AND its analytic
+// derivative for velocity. Velocity at integer keyframes equals the
+// stored value exactly; velocity at fractional indices is consistent
+// with the Hermite-interpolated position.
+export function readBodyStateInto(
+  outPos: ThreeVector3,
+  outVel: ThreeVector3,
+  buffer: ChunkBuffer,
+  floatIdx: number,
+  bodyIdx: number,
+): void {
+  if (floatIdx <= 0 || buffer.totalTimesteps <= 1) {
+    const base = 0 * buffer.bodyCount * 6 + bodyIdx * 6;
+    outPos.x = buffer.positions[base];
+    outPos.y = buffer.positions[base + 1];
+    outPos.z = buffer.positions[base + 2];
+    outVel.x = buffer.positions[base + 3];
+    outVel.y = buffer.positions[base + 4];
+    outVel.z = buffer.positions[base + 5];
+    return;
+  }
+  if (floatIdx >= buffer.totalTimesteps - 1) {
+    const base =
+      (buffer.totalTimesteps - 1) * buffer.bodyCount * 6 + bodyIdx * 6;
+    outPos.x = buffer.positions[base];
+    outPos.y = buffer.positions[base + 1];
+    outPos.z = buffer.positions[base + 2];
+    outVel.x = buffer.positions[base + 3];
+    outVel.y = buffer.positions[base + 4];
+    outVel.z = buffer.positions[base + 5];
+    return;
+  }
+
+  const i0 = Math.floor(floatIdx);
+  const s = floatIdx - i0;
+
+  if (s === 0) {
+    const base = i0 * buffer.bodyCount * 6 + bodyIdx * 6;
+    outPos.x = buffer.positions[base];
+    outPos.y = buffer.positions[base + 1];
+    outPos.z = buffer.positions[base + 2];
+    outVel.x = buffer.positions[base + 3];
+    outVel.y = buffer.positions[base + 4];
+    outVel.z = buffer.positions[base + 5];
+    return;
+  }
+
+  const stride = buffer.bodyCount * 6;
+  const base0 = i0 * stride + bodyIdx * 6;
+  const base1 = base0 + stride;
+
+  const dtMs = Number(buffer.timestamps[i0 + 1] - buffer.timestamps[i0]);
+  const dt = dtMs / 1000;
+
+  const s2 = s * s;
+  const s3 = s2 * s;
+
+  const h00 = 2 * s3 - 3 * s2 + 1;
+  const h10 = s3 - 2 * s2 + s;
+  const h01 = -2 * s3 + 3 * s2;
+  const h11 = s3 - s2;
+
+  // Derivatives of the basis wrt s.
+  const dh00 = 6 * s2 - 6 * s;
+  const dh10 = 3 * s2 - 4 * s + 1;
+  const dh01 = -6 * s2 + 6 * s;
+  const dh11 = 3 * s2 - 2 * s;
+  const invDt = 1 / dt;
+
+  const p0x = buffer.positions[base0];
+  const p0y = buffer.positions[base0 + 1];
+  const p0z = buffer.positions[base0 + 2];
+  const v0x = buffer.positions[base0 + 3];
+  const v0y = buffer.positions[base0 + 4];
+  const v0z = buffer.positions[base0 + 5];
+  const p1x = buffer.positions[base1];
+  const p1y = buffer.positions[base1 + 1];
+  const p1z = buffer.positions[base1 + 2];
+  const v1x = buffer.positions[base1 + 3];
+  const v1y = buffer.positions[base1 + 4];
+  const v1z = buffer.positions[base1 + 5];
+
+  outPos.x = h00 * p0x + h10 * dt * v0x + h01 * p1x + h11 * dt * v1x;
+  outPos.y = h00 * p0y + h10 * dt * v0y + h01 * p1y + h11 * dt * v1y;
+  outPos.z = h00 * p0z + h10 * dt * v0z + h01 * p1z + h11 * dt * v1z;
+
+  // Velocity = d/dt of position. Chain rule: ds/dt = 1/dt for the basis,
+  // tangent terms have an extra dt that cancels.
+  outVel.x = (dh00 * p0x + dh01 * p1x) * invDt + dh10 * v0x + dh11 * v1x;
+  outVel.y = (dh00 * p0y + dh01 * p1y) * invDt + dh10 * v0y + dh11 * v1y;
+  outVel.z = (dh00 * p0z + dh01 * p1z) * invDt + dh10 * v0z + dh11 * v1z;
+}
+```
+
+- [ ] **Step 4: Run all chunkBuffer tests, verify they pass.**
+
+```bash
+cd frontend && npm test -- chunkBuffer.test.ts
+```
+
+Expected: all tests pass — regression tests, position-Hermite tests, state-Hermite tests all green.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add frontend/src/app/store/chunkBuffer.ts frontend/src/app/store/chunkBuffer.test.ts
+git commit -m "feat(chunkBuffer): cubic Hermite interpolation in readBodyStateInto
+
+Velocity at fractional indices = analytic derivative of the Hermite
+position curve. At integer keyframes velocity equals the stored value
+exactly; at fractional values it stays consistent with the interpolated
+position so OrbitPath's Keplerian fit (the main fractional consumer of
+state) sees a coherent (r, v) pair."
+```
+
+---
+
+## Task 5: Boundary and edge-case tests
+
+**Files:**
+- Modify: `frontend/src/app/store/chunkBuffer.test.ts`
+
+- [ ] **Step 1: Add boundary and single-keyframe tests.**
+
+Append:
+
+```ts
+describe("readBodyPositionInto — boundaries and edge cases", () => {
+  it("clamps floatIdx > totalTimesteps - 1 to last keyframe", () => {
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      1, 2, 3, 0, 0, 0,
+      4, 5, 6, 0, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, 999, 0); // way past end
+    expect(out.x).toBe(4);
+    expect(out.y).toBe(5);
+    expect(out.z).toBe(6);
+  });
+
+  it("clamps floatIdx < 0 to first keyframe", () => {
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      1, 2, 3, 0, 0, 0,
+      4, 5, 6, 0, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, -5, 0);
+    expect(out.x).toBe(1);
+    expect(out.y).toBe(2);
+    expect(out.z).toBe(3);
+  });
+
+  it("returns first-keyframe values for a single-keyframe buffer", () => {
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([1, 2, 3, 0, 0, 0]);
+    const timestamps = new BigInt64Array([0n]);
+    appendChunk(buf, positions, timestamps, 1);
+
+    const out = new THREE.Vector3();
+    // Even at fractional, no Hermite possible → should return keyframe 0.
+    readBodyPositionInto(out, buf, 0.5, 0);
+    expect(out.x).toBe(1);
+    expect(out.y).toBe(2);
+    expect(out.z).toBe(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run all chunkBuffer tests, verify pass.**
+
+```bash
+cd frontend && npm test -- chunkBuffer.test.ts
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add frontend/src/app/store/chunkBuffer.test.ts
+git commit -m "test(chunkBuffer): boundary clamping and single-keyframe edge cases
+
+Out-of-range float indices clamp to first/last keyframe; single-keyframe
+buffer falls back gracefully to the only keyframe's stored values."
+```
+
+---
+
+## Task 6: Extract `computeNextIndex` helper for AnimationController
+
+**Why extract:** AnimationController is tightly coupled to R3F's `useFrame` and the redux store, making it hard to unit-test directly. The next-index math is pure — extracting it lets us TDD that independently and reduces AnimationController to a thin wiring layer.
+
+**Files:**
+- Create: `frontend/src/app/utils/animationStep.ts`
+- Create: `frontend/src/app/utils/animationStep.test.ts`
+
+- [ ] **Step 1: Write the failing test.**
+
+Create `frontend/src/app/utils/animationStep.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { computeNextIndex } from "./animationStep";
+
+describe("computeNextIndex", () => {
+  it("at speedMultiplier=1, FPS=60, delta=1/60s → moves 1 unit forward", () => {
+    const next = computeNextIndex({
+      currentIndex: 100,
+      delta: 1 / 60,
+      speedMultiplier: 1,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBeCloseTo(101, 10);
+  });
+
+  it("at speedMultiplier=2, doubles the step rate", () => {
+    const next = computeNextIndex({
+      currentIndex: 100,
+      delta: 1 / 60,
+      speedMultiplier: 2,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBeCloseTo(102, 10);
+  });
+
+  it("negative speedMultiplier moves backward", () => {
+    const next = computeNextIndex({
+      currentIndex: 100,
+      delta: 1 / 60,
+      speedMultiplier: -1,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBeCloseTo(99, 10);
+  });
+
+  it("clamps to upper bound at totalTimesteps - 1", () => {
+    const next = computeNextIndex({
+      currentIndex: 9_999.5,
+      delta: 1 / 60,
+      speedMultiplier: 100,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBe(9_999);
+  });
+
+  it("clamps to lower bound at 0", () => {
+    const next = computeNextIndex({
+      currentIndex: 0.5,
+      delta: 1 / 60,
+      speedMultiplier: -100,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBe(0);
+  });
+
+  it("returns fractional values for sub-frame motion", () => {
+    // At 144Hz with speedMultiplier=1, delta ≈ 1/144, expected step ≈ 60/144 ≈ 0.417
+    const next = computeNextIndex({
+      currentIndex: 0,
+      delta: 1 / 144,
+      speedMultiplier: 1,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBeCloseTo(60 / 144, 6);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify the tests fail with "module not found" or "computeNextIndex is not a function".**
+
+```bash
+cd frontend && npm test -- animationStep.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Write the implementation.**
+
+Create `frontend/src/app/utils/animationStep.ts`:
+
+```ts
+// Pure helper for AnimationController's per-frame index update. Extracted
+// for unit-testability — AnimationController itself is tightly coupled to
+// R3F's useFrame and the redux store, but the math is just arithmetic +
+// clamping.
+//
+// The drive model is wall-clock-rate: per real-world second of elapsed
+// playback, the simulation advances `speedMultiplier * fps` keyframe units.
+// At fps=60 and speedMultiplier=1 this exactly matches the legacy
+// integer-step throttled behavior (one step per 1/60s frame). At higher
+// refresh rates, the per-frame step naturally shrinks below 1.0 — the
+// chunkBuffer reads will Hermite-interpolate.
+//
+// Output is a float; clamped to [0, totalTimesteps - 1].
+export interface ComputeNextIndexInput {
+  currentIndex: number;
+  delta: number;          // seconds since last frame (from R3F useFrame)
+  speedMultiplier: number; // signed; magnitude scales rate, sign sets direction
+  fps: number;            // nominal sim FPS — defines the "1 unit per frame" baseline
+  totalTimesteps: number; // upper-bound (clamp at totalTimesteps - 1)
+}
+
+export function computeNextIndex(input: ComputeNextIndexInput): number {
+  const { currentIndex, delta, speedMultiplier, fps, totalTimesteps } = input;
+  const proposed = currentIndex + delta * fps * speedMultiplier;
+  if (proposed < 0) return 0;
+  if (proposed > totalTimesteps - 1) return totalTimesteps - 1;
+  return proposed;
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass.**
+
+```bash
+cd frontend && npm test -- animationStep.test.ts
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add frontend/src/app/utils/animationStep.ts frontend/src/app/utils/animationStep.test.ts
+git commit -m "feat(animation): extract computeNextIndex helper for wall-clock-rate driving
+
+Pure function — proposed index = current + delta·fps·speedMultiplier,
+clamped to [0, totalTimesteps - 1]. Output is float; the chunkBuffer
+read functions handle interpolation between keyframes. AnimationController
+will switch to using this in the next commit."
+```
+
+---
+
+## Task 7: Wire AnimationController to the new helper + drop useSelector subscription
+
+**Files:**
+- Modify: `frontend/src/app/components/scene/AnimationController.tsx`
+
+This task has no automated test — AnimationController is verified visually in the dev server (Task 9). The wiring is small and the math is already covered by Task 6.
+
+- [ ] **Step 1: Replace the entire `AnimationController` component body.**
+
+Open `frontend/src/app/components/scene/AnimationController.tsx`. Replace the file's contents with:
+
+```tsx
+"use client";
+
+import { useFrame } from "@react-three/fiber";
+import { useEffect, useRef } from "react";
+import { useDispatch, useSelector, useStore } from "react-redux";
+import {
+  selectIsPaused,
+  selectSpeedMultiplier,
+  setCurrentTimeStepIndex,
+} from "@/app/store/slices/SimulationSlice";
+import SimConstants from "@/app/constants/SimConstants";
+import { AppDispatch, RootState } from "@/app/store/Store";
+import { computeNextIndex } from "@/app/utils/animationStep";
+
+const AnimationController = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const store = useStore<RootState>();
+  // Note: NOT subscribing to currentTimeStepIndex via useSelector — this
+  // component dispatches that value every frame, so a selector subscription
+  // would re-render every frame (the known offender flagged in
+  // frontend-render-loop.md). We read it imperatively from store.getState()
+  // inside useFrame instead.
+  const isPaused = useSelector(selectIsPaused);
+  const speedMultiplier = useSelector(selectSpeedMultiplier);
+
+  const isPausedRef = useRef(isPaused);
+  const speedMultiplierRef = useRef(speedMultiplier);
+
+  useEffect(() => {
+    isPausedRef.current = isPaused;
+  }, [isPaused]);
+  useEffect(() => {
+    speedMultiplierRef.current = speedMultiplier;
+  }, [speedMultiplier]);
+
+  useFrame((_, delta) => {
+    if (isPausedRef.current) return;
+
+    const state = store.getState();
+    const buffer = state.simulation.chunkBuffer;
+    if (!buffer || buffer.totalTimesteps === 0) return;
+
+    const currentIndex = state.simulation.timeState.currentTimeStepIndex;
+    const nextIndex = computeNextIndex({
+      currentIndex,
+      delta,
+      speedMultiplier: speedMultiplierRef.current,
+      fps: SimConstants.FPS,
+      totalTimesteps: buffer.totalTimesteps,
+    });
+
+    if (nextIndex !== currentIndex) {
+      dispatch(setCurrentTimeStepIndex(nextIndex));
+    }
+  });
+
+  return null;
+};
+
+export default AnimationController;
+```
+
+Changes from the previous version:
+- Dropped `selectCurrentTimeStepIndex` import + selector subscription + matching ref/useEffect.
+- Dropped `FRAME_INTERVAL` accumulator (`accRef`, `FRAME_INTERVAL` constant). Wall-clock-rate driving is naturally framerate-independent — no need to throttle.
+- Index math delegated to `computeNextIndex`.
+- Comparison `nextIndex !== currentIndex` skips the dispatch when motion would be zero (paused already-handled; this catches the edge where clamp produced no movement).
+
+- [ ] **Step 2: Run frontend lint + tests to confirm no compilation issues.**
+
+```bash
+cd frontend && npm run lint && npm test
+```
+
+Expected: lint passes, all tests still pass.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add frontend/src/app/components/scene/AnimationController.tsx
+git commit -m "refactor(scene): wall-clock-rate float-index driving in AnimationController
+
+Switches from throttled integer-step motion to wall-clock-rate float motion
+via the new computeNextIndex helper. currentTimeStepIndex becomes a float;
+all chunkBuffer consumers transparently propagate it.
+
+Also drops the useSelector subscription on currentTimeStepIndex (a known
+offender per frontend-render-loop.md — this component dispatched the same
+value every frame, causing a render cascade). Reads imperatively via
+store.getState() inside useFrame instead."
+```
+
+---
+
+## Task 8: Camera per-frame Vector3 allocation cleanup (opportunistic)
+
+**Why now:** Spec calls for fixing this opportunistically while in the file for Phase 1's smoothness verification. The file is already in scope.
+
+**Files:**
+- Modify: `frontend/src/app/components/scene/Camera.tsx`
+
+- [ ] **Step 1: Read the file to locate the per-frame allocation.**
+
+```bash
+cd /Users/byeonkho/code/spacesim && grep -n "new THREE.Vector3" frontend/src/app/components/scene/Camera.tsx
+```
+
+Expected: shows the allocation site(s) inside `useFrame`.
+
+- [ ] **Step 2: Hoist allocation(s) to module-level scratch vectors (or `useRef` if the camera component re-mounts).**
+
+Pattern: replace `const v = new THREE.Vector3()` inside `useFrame` with:
+
+```tsx
+// At module level, above the component:
+const scratchVec = new THREE.Vector3();
+
+// Inside useFrame, replace `new THREE.Vector3()` with reuse-then-reset:
+scratchVec.set(0, 0, 0);
+// ... use scratchVec ...
+```
+
+If Camera might mount multiple times (check if it does), use `useRef(new THREE.Vector3())` instead, accessed as `scratchVecRef.current`. The render-loop rules note `Camera` is a single instance, so module-level is fine.
+
+- [ ] **Step 3: Run frontend tests + lint to confirm no breakage.**
+
+```bash
+cd frontend && npm run lint && npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add frontend/src/app/components/scene/Camera.tsx
+git commit -m "perf(scene): hoist per-frame Vector3 allocation in Camera
+
+Removes a per-frame allocation flagged in frontend-render-loop.md as a
+known offender. Opportunistic cleanup while in the file for Phase 1
+smoothness verification."
+```
+
+---
+
+## Task 9: Full verification — build, lint, tests, manual smoothness check
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full backend + frontend verify per CLAUDE.md.**
+
+```bash
+cd /Users/byeonkho/code/spacesim/frontend && npm run build && npm run lint && npm test
+```
+
+Expected: build succeeds, lint clean, all tests pass.
+
+- [ ] **Step 2: Start the backend.**
+
+```bash
+cd /Users/byeonkho/code/spacesim/backend && ./mvnw spring-boot:run
+```
+
+Expected: starts on port 8080, no errors in logs.
+
+- [ ] **Step 3: Start the frontend dev server.**
+
+```bash
+cd /Users/byeonkho/code/spacesim/frontend && npm run dev
+```
+
+Expected: starts on port 3000.
+
+- [ ] **Step 4: Manual verification checklist.**
+
+In a browser at `http://localhost:3000`:
+
+- [ ] Submit a default sim. Wait for first chunk to load.
+- [ ] Press play at speedMultiplier=1. **Verify:** motion is visibly smoother than master — no per-step stutter; bodies appear to move continuously between integration samples.
+- [ ] Open the Stats overlay (DevPanel or Stats.js). **Verify:** steady-state FPS is the same as master under the same scene + body count (no measurable regression).
+- [ ] Increase speedMultiplier to +5 or higher. **Verify:** motion stays smooth, no drift in position vs. master at the same sim time.
+- [ ] Set speedMultiplier to -1. **Verify:** smooth backward playback.
+- [ ] Pause. Drag the scrubber to a different position. **Verify:** scene snaps to the scrubbed time, all bodies land in the right spot.
+- [ ] Click on a body to focus. **Verify:** camera follows the body smoothly through fractional time positions.
+- [ ] With a body focused, observe the orbit path. **Verify:** orbit ellipse stays correct and stable through animation (Hermite-interpolated velocity flowing into Keplerian fit doesn't introduce wobble).
+- [ ] Observe a body's trail. **Verify:** trail head sits exactly on the body (no lag, no jump); trail body looks identical to master.
+- [ ] Toggle helio ↔ geo display frame. **Verify:** Earth pivots correctly in geo mode; no jitter introduced by Hermite at the pivot.
+
+If anything regresses: stop, diagnose, fix before declaring done.
+
+- [ ] **Step 5: Push the branch.**
+
+```bash
+cd /Users/byeonkho/code/spacesim && git push -u origin hermite-frontend
+```
+
+- [ ] **Step 6: Open the PR.**
+
+```bash
+gh pr create --title "Phase 1: Cubic Hermite interpolation + wall-clock-rate animation driving" --body "$(cat <<'EOF'
+## Summary
+
+- Widens `readBodyPositionInto` and `readBodyStateInto` in chunkBuffer to accept float `floatIdx` — integer values short-circuit to direct typed-array reads (zero perf cost), fractional values perform inline cubic Hermite using stored velocities as tangents.
+- Switches AnimationController from integer-step throttled motion to wall-clock-rate float motion via a new `computeNextIndex` helper. Drops the FRAME_INTERVAL accumulator (no longer needed — wall-clock driving is framerate-independent) and the useSelector subscription on `currentTimeStepIndex` (known render-cascade offender).
+- Opportunistic cleanup: per-frame `new THREE.Vector3` allocation in Camera hoisted to module scratch.
+
+Spec: `docs/superpowers/specs/2026-05-15-hermite-keyframe-interpolation-design.md`
+
+Phase 1 of 3. Phase 2 (backend keyframe thinning) and Phase 3 (SimParams UI) follow after this verifies + merges.
+
+## Test plan
+
+- [ ] `npm test` passes (chunkBuffer Hermite tests, animationStep helper tests, all existing tests still green)
+- [ ] `npm run build && npm run lint` clean
+- [ ] Manual smoothness check (see Task 9 in `docs/superpowers/plans/2026-05-15-hermite-phase-1-frontend-interpolation.md` step 4)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed. Stop here — do NOT poll CI per `.claude/rules/no-ci-polling.md`. Report PR URL and end.
+
+---
+
+## Self-review checklist (verified before handing off plan)
+
+**Spec coverage:**
+- [x] Hermite math in `readBodyPositionInto` (Task 3)
+- [x] Hermite math in `readBodyStateInto` (Task 4)
+- [x] Boundary handling (clamp at both ends) (Tasks 3, 4, 5)
+- [x] Single-keyframe edge case (Task 5)
+- [x] s=0 fast path / regression coverage (Task 1)
+- [x] Wall-clock-rate driving in AnimationController (Tasks 6, 7)
+- [x] Drop useSelector subscription on `currentTimeStepIndex` (Task 7)
+- [x] Camera per-frame allocation cleanup (Task 8)
+- [x] Verify criterion: smoothness, FPS, scrubber, click-focus, orbit-path, trail (Task 9 manual checklist)
+
+**Type / signature consistency:**
+- `ComputeNextIndexInput` shape used in Task 6 matches the call in Task 7. ✓
+- `readBodyPositionInto` / `readBodyStateInto` signatures unchanged externally — only docstring + behavior. ✓
+
+**Placeholder scan:** No TBD / TODO / fill-in markers. Every step shows the exact code or command.

--- a/docs/superpowers/specs/2026-05-15-hermite-keyframe-interpolation-design.md
+++ b/docs/superpowers/specs/2026-05-15-hermite-keyframe-interpolation-design.md
@@ -1,0 +1,368 @@
+# Hermite keyframe interpolation + backend keyframe thinning
+
+**Date:** 2026-05-15
+**Status:** Design — awaiting implementation
+**Tracker entry:** `todo.md` #20 (originally "Catmull-Rom interpolation"; revised to cubic Hermite)
+**Related:** `todo.md` #37 (per-chunk bandwidth optimisation), #68 (DP853 native adaptive substep — depends on this work landing first)
+
+## Summary
+
+Replace the current behavior — backend ships every integration step, frontend snaps directly to discrete samples — with cubic Hermite interpolation between sparser, backend-thinned keyframes. Two payoffs: smoother animation between samples (independent of bandwidth), and a per-request bandwidth lever (skip every Kth raw step). Three independent rollout phases, each verifiable on its own.
+
+## Goals
+
+- Smoother visual playback between integration samples — no per-step "stutter" at any playback speed.
+- Reduce per-chunk bandwidth via configurable keyframe thinning, with sensible per-integrator defaults.
+- User-visible "Playback quality" control surfaced in SimParams.
+- Zero correctness regressions; existing scrubber, click-to-focus, and orbit-path behavior preserved.
+
+## Non-goals
+
+- Re-timing adaptive integrators onto a different sample grid. (DP853 is currently driven at fixed external dt — see `Investigation findings` below — so re-timing collapses to a no-op.)
+- Exposing DP853's native adaptive substep cadence. Filed as `todo.md` #68; depends on this work landing first.
+- Changing the wire format. Per-keyframe timestamps are already shipped; only the read side needs to honor non-uniform spacing.
+- Float32 quantization of position/velocity (see `todo.md` #37 — orthogonal future bandwidth lever).
+
+## Investigation findings
+
+Before locking the design, the integrator pipeline was audited:
+
+1. **Backend ships state vectors (px, py, pz, vx, vy, vz) per body per timestep**, see `BinaryResponseSerializer.java:88-94`. Velocities are already on the wire — Hermite has the data it needs without a protocol change.
+
+2. **Frontend chunkBuffer already stores velocities** alongside positions in the same flat typed-array. `readBodyStateInto` (no-allocation, scratch-vector pattern) already exists in `chunkBuffer.ts:153`.
+
+3. **All three integrators emit uniform-time samples.** `Simulation.run()` (`Simulation.java:115-119`) is a fixed-dt loop calling `integrator.stepInto(out, state, dt, derivatives)`. DP853's adaptive behavior is *internal* to its `stepInto` call (Hipparchus substeps adaptively to land at t+dt with tight tolerances) but the substeps are discarded; only the endpoint is returned. Consequence: the original "re-timing for adaptive integrators" lever is unnecessary today.
+
+4. **Per-keyframe timestamps are already in the wire format** (`int64 millis` per timestep). The format never assumed uniform spacing — frontend code did. After this work, that assumption is removed.
+
+5. **Hot-path discipline applies.** `frontend-render-loop.md` and `backend-sim-step.md` both apply. New code must avoid per-frame allocations, avoid per-step allocations in the integrator/serializer loops, and respect the existing scratch-buffer + caller-provided-output patterns.
+
+## Algorithm — cubic Hermite vs. Catmull-Rom
+
+Both are cubic splines through control points. The difference is how the tangent at each point is computed:
+
+- **Catmull-Rom** estimates the tangent at point P₁ as `(P₂ − P₀) / 2` — a finite difference of neighboring positions. Wrong by O(dt²) compared to the true derivative.
+- **Cubic Hermite** uses an explicit tangent at each endpoint. We have the integrator's exact velocity at every keyframe, so the tangent IS the velocity — no estimation.
+
+Same flop count (~30 per axis per body per frame, ~90 total per body per frame). Hermite is strictly more accurate at every sample point and degrades more gracefully as keyframes are thinned (Catmull-Rom's tangent estimates degrade with sparser sampling; Hermite's tangents are still exact). Hermite's analytic derivative also gives interpolated velocity matching the integrator exactly at keyframes — directly usable by `OrbitPath` for its Keplerian fit.
+
+### Hermite math (the form used)
+
+Between keyframes `i` and `i+1` with timestamps `t0`, `t1` (in seconds):
+
+```
+s = floatIdx - floor(floatIdx)        # ∈ [0, 1]
+dt = t1 - t0
+
+h00 = 2s³ - 3s² + 1
+h10 = s³ - 2s² + s
+h01 = -2s³ + 3s²
+h11 = s³ - s²
+
+p(s)  = h00·p0 + h10·dt·v0 + h01·p1 + h11·dt·v1
+p'(s) = (h00'·p0 + h01'·p1) / dt + h10'·v0 + h11'·v1
+```
+
+Computed inline per axis against the typed-array backing store. No Three.js wrapper objects, no allocations.
+
+## Rollout — three phases
+
+Each phase ships on its own branch, opens its own PR, and waits for explicit verify-and-merge before the next phase begins. Per `branch-workflow.md`.
+
+| Phase | Branch | Scope | Independent verify criterion |
+|---|---|---|---|
+| 1 | `hermite-frontend` | Frontend Hermite + float-keyframe index. Zero protocol change. | Animation visibly smoother at any speed; chunk sizes unchanged; FPS unchanged. |
+| 2 | `hermite-backend-thinning` | Backend honors `keyframeIntervalSec` request param. Frontend sends `stepDt` (no change). | Sending `stepDt` produces identical chunk sizes; sending `4·stepDt` produces ~75% smaller chunks; cross-chunk continuity preserved. |
+| 3 | `hermite-ui` | Per-integrator default N + 5-preset SimParams control + custom override. | User sees "Playback quality" control; switching integrators auto-selects preset; payload size in DevTools matches selection. |
+
+## Phase 1 — Frontend Hermite (no protocol change)
+
+### Animation drive model
+
+`AnimationController.tsx` currently advances `currentTimeStepIndex` by integer `speedMultiplier` per frame fire. With integer index, there's nothing fractional for Hermite to interpolate.
+
+Switch to wall-clock-rate driving:
+
+```
+nextIndex = currentIndex + (delta · stepsPerSec · direction)
+```
+
+where `stepsPerSec = speedMultiplier · FPS`. Preserves today's behavior at speedMultiplier=1 (same total displacement per second), but `currentTimeStepIndex` becomes a float. Bonus: playback rate becomes framerate-independent.
+
+The accumulator/throttle pattern (`accRef`, `FRAME_INTERVAL`) stays — fires at FPS rate.
+
+### Slice changes — `SimulationSlice.ts`
+
+- `currentTimeStepIndex: number` — type unchanged; semantics now "float over kept keyframes; integer = on a keyframe, fractional = interpolated."
+- `setCurrentTimeStepIndex(payload: number)` — accepts float. Clamping `[0, totalTimesteps - 1]` unchanged.
+- Eviction-shift handler at line 252-254 (`currentTimeStepIndex - shifted`) works for floats with no change.
+- Scrubber stays integer (`Math.round(...)` in `Timeline.tsx:182`) — fractional scrubbing adds nothing perceptible.
+
+### chunkBuffer additions — `chunkBuffer.ts`
+
+Two new read functions, allocation-free, caller-provided scratch vectors:
+
+```ts
+readBodyPositionAtFrac(
+  out: Vector3,
+  buffer: ChunkBuffer,
+  floatIdx: number,
+  bodyIdx: number,
+): void
+
+readBodyStateAtFrac(
+  outPos: Vector3,
+  outVel: Vector3,
+  buffer: ChunkBuffer,
+  floatIdx: number,
+  bodyIdx: number,
+): void
+```
+
+Both perform Hermite inline against the typed-array backing store. Existing integer-index `readBodyPositionInto` / `readBodyStateInto` stay for non-animation callers (Trail tail iteration, etc.).
+
+Boundary handling: `floatIdx >= totalTimesteps - 1` → clamp to last keyframe's stored values (no Hermite). `floatIdx < 0` → clamp to first. No special-case across chunk boundaries because the buffer is contiguous regardless of which raw chunk a keyframe came from.
+
+### Scene consumer audit
+
+Per `frontend-render-loop.md` "audit EVERY consumer" rule. Every site that reads body position via integer-index becomes a float-index read:
+
+| File | Change | Notes |
+|---|---|---|
+| `Sphere.tsx` | `readBodyPositionInto` → `readBodyPositionAtFrac` | Direct swap |
+| `Trail.tsx` | Tail loop unchanged (integer past-keyframe iteration); **head** position becomes fractional | Trail head is the only fractional read; trail body is `start..end-1` integer iteration |
+| `OrbitPath.tsx` | `readBodyStateInto` → `readBodyStateAtFrac` | Uses interpolated velocity for Keplerian fit — matches interpolated position |
+| `Reticle.tsx` | Position read → fractional | |
+| `GhostLabel.tsx` | Position read → fractional | |
+| `Camera.tsx` | Focused-body position read → fractional | Existing per-frame `new THREE.Vector3` allocation (flagged in render-loop rules as known offender) — fix opportunistically while in the file |
+| `framePivot` helper | `writePivotInto(pivot, buffer, idx, frame)` → accept float idx; Hermite at fractional, exact keyframe at integer (Hermite degenerates to keyframe at s=0) | Single read API consumed by all six scene components above. Trail's tail loop passes int (gets exact); head passes float (gets interpolated). No call-site changes beyond the type widening |
+| `BodyCard.tsx` | `currentTimeStepIndex` consumer for display | Display strings can use fractional state |
+
+### AnimationController known-offender cleanup
+
+Currently subscribes to `currentTimeStepIndex` via `useSelector` then dispatches it every frame — re-renders every frame. Flagged in `frontend-render-loop.md` as a known offender. Recommend folding the fix in here: switch to imperative `store.getState()` inside `useFrame`, drop the selector subscription. Same file, same set of refs, the change is already adjacent.
+
+### Hot-path discipline
+
+- All Hermite math inline against typed arrays.
+- Caller-provided scratch vectors throughout (matches existing `readBody*Into` pattern).
+- Per-frame cost: O(N_bodies) Hermite computations × ~90 flops = negligible. Doesn't degrade with sim time, buffered timesteps, or chunk size.
+
+### Phase 1 tests — `chunkBuffer.test.ts`
+
+- `readBodyPositionAtFrac` at integer index returns p0 exactly.
+- `readBodyPositionAtFrac` at integer+1 returns p1 exactly.
+- `readBodyStateAtFrac` velocity at integer keyframe matches stored velocity exactly (Hermite degenerates correctly).
+- Hermite passes through endpoints with correct tangents (synthesize a two-keyframe buffer with known motion → verify intermediate value against analytical formula).
+- Boundary clamping: floatIdx > `totalTimesteps - 1` → returns last keyframe values; floatIdx < 0 → returns first.
+- Single-keyframe buffer: falls back gracefully to that keyframe's position (no Hermite).
+
+### Phase 1 verify criterion
+
+- Animation at speedMultiplier=1 visibly smoother — no per-step stutter, motion appears continuous between integration samples.
+- Total wall-clock time to play one chunk unchanged.
+- Steady-state FPS (Stats.js or DevPanel readout) shows no measurable drop vs. master under the same scene + body count.
+- Scrubber, scene-click, focus, orbit-path, and trail rendering all behave identically to master.
+
+## Phase 2 — Backend keyframe thinning
+
+### DTO change — `SimulationRequestDTO.java`
+
+Add `keyframeIntervalSec` (optional, nullable Double). Set once per session at simulation creation; applies to all chunks of that session. `SimulationChunkRequest` is unchanged (server already has the value from the original DTO).
+
+```java
+public record SimulationRequestDTO(
+    List<String> celestialBodyNames,
+    String date,
+    String frame,
+    String integrator,
+    String timeStepUnit,
+    Double keyframeIntervalSec  // null → server defaults to stepDt (no thinning)
+) {}
+```
+
+### Backend resolution
+
+Compute once at simulation construction:
+
+```
+K = max(1, round(keyframeIntervalSec / stepDtSeconds))
+```
+
+Store on `Simulation` as `final int keyframesPerKept`. If `keyframeIntervalSec` is null, K = 1.
+
+Validation in service layer (not in the integrator hot path):
+
+- `1 <= K <= MAX_K` where `MAX_K = 100` (with default CHUNK_SIZE=10000, this leaves at least 100 keyframes per chunk — visual smoothness floor).
+- Reject with HTTP 400 if out of range.
+- API contract documents that `keyframeIntervalSec` may be rounded to the nearest integer multiple of stepDt.
+
+### `Simulation.run()` change
+
+Track a global step counter that persists across `run()` invocations, so chunk boundaries don't reset the modulo and produce visible gaps:
+
+```java
+private long globalStepCount = 0;       // monotonic across all chunks
+private long nextKeptAtStep = 0;        // next global step to emit
+
+public Map<...> run() {
+    ...
+    if (!hasEmittedInitialFrame) {
+        results.put(simCurrentDate, snapshotFromState());  // step 0 always kept
+        hasEmittedInitialFrame = true;
+        nextKeptAtStep = keyframesPerKept;
+    }
+
+    int currentTimeStep = 0;
+    while (currentTimeStep < TIMESTEPS_TO_RUN) {
+        update();
+        globalStepCount++;
+        if (globalStepCount >= nextKeptAtStep) {
+            results.put(simCurrentDate, snapshotFromState());
+            nextKeptAtStep += keyframesPerKept;
+        }
+        currentTimeStep++;
+    }
+    ...
+}
+```
+
+This guarantees uniform K-step spacing across all chunks: the next chunk's first kept keyframe is exactly K steps after the previous chunk's last kept keyframe. No visible gap or stutter at boundaries.
+
+### Hot-path discipline (per `backend-sim-step.md`)
+
+- The K=1 fast path must not regress (default behavior). The `if (globalStepCount >= nextKeptAtStep)` is a single integer comparison; with K=1 it's true every step → identical to today.
+- `snapshotFromState()` unchanged. With K=4, snapshot allocation pressure drops 75% (snapshots only constructed for kept steps).
+- No collection pre-sizing change needed (`LinkedHashMap` sizes itself to insertions).
+
+### Wire format
+
+**Zero changes.** With K=4, the `timestepCount` header field is ~2500 instead of ~10000, and per-step timestamps are spaced K·stepDt apart. Frontend reconstructs Hermite intervals from those timestamps directly.
+
+### Frontend changes (Phase 2 only)
+
+- Add `keyframeIntervalSec` to the SimRequest builder/types.
+- Default value: `stepDt` (no behavior change). Per-integrator defaults arrive in Phase 3.
+- No UI surface yet.
+- chunkBuffer code already handles non-uniform timestamps correctly (Phase 1's Hermite uses per-keyframe timestamps for `dt`).
+
+### Phase 2 tests
+
+- **Backend `SimulationTest`:**
+  - K=1 emits 10001 kept frames per first chunk (initial + 10000 steps).
+  - K=4 emits 2501 kept frames per first chunk (initial + steps 4, 8, ..., 10000).
+  - K=8 emits 1251 kept frames per first chunk.
+  - Cross-chunk continuity: run two consecutive chunks at K=4; assert the second chunk's first kept keyframe is exactly K-spaced from the first chunk's last (no boundary gap).
+  - Edge: validate K > TIMESTEPS_TO_RUN behavior. Service-layer validation should prevent it; document expected fallback if it slips through.
+- **Service-layer test:** validation rejects K < 1 and K > MAX_K with HTTP 400.
+- **`BinaryResponseSerializerTest`:** unchanged (format identical). Optional integration test that decodes a thinned chunk end-to-end.
+- **Frontend SimRequest test:** `keyframeIntervalSec` is included in the request body when set.
+
+### Phase 2 verify criterion
+
+- `keyframeIntervalSec = stepDt` (or omitted) → identical chunk size + identical playback as before this PR.
+- `keyframeIntervalSec = 4·stepDt` → ~75% smaller compressed chunks; visual playback indistinguishable from K=1 (Hermite working as designed).
+- Two consecutive chunks at K=4 show no visual stutter at the boundary.
+
+## Phase 3 — UI surface
+
+### Constants — new `PlaybackQuality.ts` under `frontend/src/app/constants/`
+
+```ts
+export const PLAYBACK_QUALITY_PRESETS = {
+  high:    { multiplier: 1,  label: "High" },
+  medHigh: { multiplier: 2,  label: "Med-High" },
+  medium:  { multiplier: 4,  label: "Medium" },
+  medLow:  { multiplier: 8,  label: "Med-Low" },
+  low:     { multiplier: 16, label: "Low" },
+} as const;
+
+export type PlaybackQualityKey = keyof typeof PLAYBACK_QUALITY_PRESETS;
+
+export const INTEGRATOR_QUALITY_DEFAULTS: Record<string, PlaybackQualityKey> = {
+  euler:  "high",      // K=1, no thinning — Euler is already crude
+  rk4:    "medium",    // K=4
+  dp853:  "medLow",    // K=8 — smooth orbits over-sampled, can thin aggressively
+};
+```
+
+The "× stepDt" framing is internal; user sees only labels + a custom input.
+
+### UI control — `SimSetupDrawer.tsx`
+
+New form field "**Playback quality**" sits under integrator + timeStepUnit (the existing pattern). Two-part control:
+
+- **Segmented radio** with 5 preset buttons (Low / Med-Low / Medium / Med-High / High) — Radix `RadioGroup` styled as a segmented control. Selecting a preset sets the multiplier; visually highlights that segment.
+- **"Custom" numeric input** below the segmented control — labeled "Custom keyframe interval (× step)". Accepts integer 1–100. When the value matches a preset, that preset highlights; when it doesn't, no preset is highlighted ("custom" state implicit).
+
+Local state in SimSetupDrawer:
+
+```ts
+const [qualityMultiplier, setQualityMultiplier] = useState<number>(
+  PLAYBACK_QUALITY_PRESETS[INTEGRATOR_QUALITY_DEFAULTS[integrator]].multiplier
+);
+```
+
+On integrator change, reset `qualityMultiplier` to the new integrator's default. Simple model — discards any custom value the user typed before changing integrator. The "sticky override" pattern (preserve custom across integrator change) is a friendliness polish, **flagged as optional follow-up.**
+
+### Validation in form
+
+- Custom input clamped to `[1, 100]` (matches backend MAX_K).
+- Inline error text under the input if user types something out of range. Submit button disabled while invalid.
+
+### Wire-up to SimRequest
+
+On submit, compute:
+
+```
+keyframeIntervalSec = qualityMultiplier · stepDtSeconds(timeStepUnit)
+```
+
+Include in the `SimulationRequestDTO`. Existing payload-building logic (around line 75 of `SimSetupDrawer`) gets one more field.
+
+### Tooltip / explainer
+
+Small info icon next to the field. Tooltip copy: "Lower quality ships fewer keyframes — smaller payloads, smoother bandwidth, but motion between samples is interpolated. Higher quality ships every step." Portfolio-readable.
+
+### State persistence
+
+Per-session only — re-derived from integrator default on each new sim setup. No localStorage. (If the redesign later persists SimParams across reloads, quality follows along automatically.)
+
+### Phase 3 tests
+
+- **SimSetupDrawer integration test:**
+  - Changing integrator updates the quality preset to the new default.
+  - Selecting a preset updates `qualityMultiplier`.
+  - Custom input outside [1, 100] shows validation error.
+- **Constants test:** every integrator key in `INTEGRATOR_QUALITY_DEFAULTS` is a valid preset key (compile-safe with TS, but a runtime smoke test catches typos).
+- **End-to-end manual check:** open SimSetupDrawer → switch integrators → observe preset auto-changes → submit with custom value → confirm payload size in DevTools matches expected ratio.
+
+### Phase 3 verify criterion
+
+- Default-flow user opens drawer → sees the new control → submits without touching it → gets per-integrator default N → backend ships thinned chunks → playback indistinguishable from current.
+- Power user picks "Low" or types custom → backend ships much smaller chunks → playback still smooth, payload reduction visible in DevTools network tab.
+- Switching integrator pre-submit → preset auto-updates to that integrator's default.
+
+## Risks and open questions
+
+- **Visual quality at high K on Euler/RK4.** Cubic interpolation of crude integration is still crude. Per-integrator defaults guard against accidentally pairing aggressive thinning with crude integration. Power users can still override; the result is "your call." Mitigation: tooltip copy makes the tradeoff explicit.
+- **Trail head appearance at fractional index.** Trail tail uses integer past-keyframes; head uses fractional Hermite. Visual continuity at the head/tail join needs verification — should be seamless because the tail's last point IS the keyframe that the Hermite curve passes through exactly at integer index, but worth a manual check during Phase 1 verification.
+- **AnimationController offender cleanup** is bundled into Phase 1 to reduce file churn. If it expands scope unexpectedly, split it back out as a follow-up.
+- **`Camera.tsx` per-frame allocation** is also bundled into Phase 1 opportunistically. Same scope-creep watch.
+- **Sticky-override UX** in Phase 3 (preserving custom value across integrator change) is deferred. If users complain, file as follow-up.
+
+## Test summary
+
+| Phase | New test files / additions |
+|---|---|
+| 1 | `chunkBuffer.test.ts` — Hermite read functions (8 cases). Manual: smoothness verification, FPS check. |
+| 2 | `SimulationTest` (backend) — K=1, K=4, K=8 keyframe counts; cross-chunk continuity. Service-layer validation test. Frontend SimRequest serialization test. |
+| 3 | `SimSetupDrawer` integration — preset selection, integrator-change reset, custom input validation. Constants smoke test. Manual: end-to-end DevTools payload-size check. |
+
+## Cross-references
+
+- `todo.md` #20 — this work.
+- `todo.md` #37 — orthogonal future bandwidth lever (Float32 quantization, delta encoding).
+- `todo.md` #68 — depends on this; exposes DP853's native adaptive substeps via the `StepHandler` API once per-keyframe-timestamp infrastructure lands here.
+- `ARCHITECTURE.md` — should gain a section under "Resolved design decisions" once Phase 3 ships, summarizing the per-keyframe-timestamps + Hermite contract for future readers.
+- Hot-path rules: `.claude/rules/frontend-render-loop.md`, `.claude/rules/backend-sim-step.md`.

--- a/docs/superpowers/specs/2026-05-15-hermite-keyframe-interpolation-design.md
+++ b/docs/superpowers/specs/2026-05-15-hermite-keyframe-interpolation-design.md
@@ -98,19 +98,28 @@ The accumulator/throttle pattern (`accRef`, `FRAME_INTERVAL`) stays — fires at
 - Eviction-shift handler at line 252-254 (`currentTimeStepIndex - shifted`) works for floats with no change.
 - Scrubber stays integer (`Math.round(...)` in `Timeline.tsx:182`) — fractional scrubbing adds nothing perceptible.
 
-### chunkBuffer additions — `chunkBuffer.ts`
+### chunkBuffer changes — `chunkBuffer.ts`
 
-Two new read functions, allocation-free, caller-provided scratch vectors:
+**Widen the existing `readBodyPositionInto` and `readBodyStateInto` to accept a float idx**, rather than adding parallel `*AtFrac` functions. Function signatures and existing call sites unchanged. Internal behavior:
+
+- At integer idx (the s=0 case), short-circuit to direct typed-array read — same path as today, single-branch overhead.
+- At fractional idx, perform cubic Hermite against the surrounding keyframes inline.
+
+Allocation-free, caller-provided scratch vectors throughout (existing pattern preserved).
 
 ```ts
-readBodyPositionAtFrac(
+// Signature unchanged; doc comment updated:
+// floatIdx ∈ [0, totalTimesteps - 1]. Integer = exact keyframe read.
+// Fractional = cubic Hermite between floor(floatIdx) and floor(floatIdx) + 1
+// using stored velocities as tangents.
+readBodyPositionInto(
   out: Vector3,
   buffer: ChunkBuffer,
   floatIdx: number,
   bodyIdx: number,
 ): void
 
-readBodyStateAtFrac(
+readBodyStateInto(
   outPos: Vector3,
   outVel: Vector3,
   buffer: ChunkBuffer,
@@ -119,24 +128,26 @@ readBodyStateAtFrac(
 ): void
 ```
 
-Both perform Hermite inline against the typed-array backing store. Existing integer-index `readBodyPositionInto` / `readBodyStateInto` stay for non-animation callers (Trail tail iteration, etc.).
+Why widen instead of adding new functions: every consumer (`Sphere`, `Trail`, `OrbitPath`, `Reticle`, `GhostLabel`, `Camera`, `BodyCard`, `framePivot`) currently passes the slice's `currentTimeStepIndex` straight through. After `AnimationController` makes that value a float, the consumers transparently forward it. No call-site migrations needed beyond AnimationController itself. Trail's tail loop still passes integer `i` and gets exact-keyframe values via the s=0 fast path — zero perf cost.
 
-Boundary handling: `floatIdx >= totalTimesteps - 1` → clamp to last keyframe's stored values (no Hermite). `floatIdx < 0` → clamp to first. No special-case across chunk boundaries because the buffer is contiguous regardless of which raw chunk a keyframe came from.
+Boundary handling: `floatIdx >= totalTimesteps - 1` → clamp to last keyframe (no Hermite). `floatIdx < 0` → clamp to first. No special-case across raw-chunk boundaries because the buffer is contiguous regardless of which chunk a keyframe came from.
 
 ### Scene consumer audit
 
-Per `frontend-render-loop.md` "audit EVERY consumer" rule. Every site that reads body position via integer-index becomes a float-index read:
+Per `frontend-render-loop.md` "audit EVERY consumer" rule. Because we widened `readBodyPositionInto` / `readBodyStateInto` rather than adding parallel functions, **none of the consumer files require code changes** — they already pass the slice's `currentTimeStepIndex` through to the read APIs unchanged. The audit confirms each consumer transparently propagates whatever index it receives:
 
-| File | Change | Notes |
-|---|---|---|
-| `Sphere.tsx` | `readBodyPositionInto` → `readBodyPositionAtFrac` | Direct swap |
-| `Trail.tsx` | Tail loop unchanged (integer past-keyframe iteration); **head** position becomes fractional | Trail head is the only fractional read; trail body is `start..end-1` integer iteration |
-| `OrbitPath.tsx` | `readBodyStateInto` → `readBodyStateAtFrac` | Uses interpolated velocity for Keplerian fit — matches interpolated position |
-| `Reticle.tsx` | Position read → fractional | |
-| `GhostLabel.tsx` | Position read → fractional | |
-| `Camera.tsx` | Focused-body position read → fractional | Existing per-frame `new THREE.Vector3` allocation (flagged in render-loop rules as known offender) — fix opportunistically while in the file |
-| `framePivot` helper | `writePivotInto(pivot, buffer, idx, frame)` → accept float idx; Hermite at fractional, exact keyframe at integer (Hermite degenerates to keyframe at s=0) | Single read API consumed by all six scene components above. Trail's tail loop passes int (gets exact); head passes float (gets interpolated). No call-site changes beyond the type widening |
-| `BodyCard.tsx` | `currentTimeStepIndex` consumer for display | Display strings can use fractional state |
+| File | Reads via | Index source | Notes |
+|---|---|---|---|
+| `Sphere.tsx` | `readBodyPositionInto` ×2 | `currentTimeStepIndex` (becomes float) | Body + parent reads — both pass the same float idx |
+| `Trail.tsx` | `readBodyPositionInto` ×2 in tail loop | `i` (always integer) | Tail uses s=0 fast path, no Hermite cost |
+| `OrbitPath.tsx` | `readBodyStateInto` ×2 | `currentTimeStepIndex` (becomes float) | Body + parent state — Hermite-interpolated velocity flows into Keplerian fit naturally |
+| `Reticle.tsx` | `readBodyPositionInto` | `currentTimeStepIndex` (becomes float) | |
+| `GhostLabel.tsx` | `readBodyPositionInto` ×3 | `currentTimeStepIndex` (becomes float) | |
+| `Camera.tsx` | `readBodyPositionInto` (via `framePivot`) | `currentTimeStepIndex` (becomes float) | Existing per-frame `new THREE.Vector3` allocation (flagged in render-loop rules as known offender) — fix opportunistically while in the file for visual smoothness verification |
+| `framePivot.ts` | `readBodyPositionInto` | passed-through `timestepIdx` | No signature change; just inherits the widened function's behavior |
+| `BodyCard.tsx` | `readBodyStateInto` ×3 | `currentTimeStepIndex` (becomes float) | Display strings naturally show fractional state |
+
+The only file with active code changes besides `chunkBuffer.ts` is `AnimationController.tsx` (drive-model switch + offender cleanup), plus the opportunistic `Camera.tsx` allocation fix.
 
 ### AnimationController known-offender cleanup
 
@@ -150,12 +161,13 @@ Currently subscribes to `currentTimeStepIndex` via `useSelector` then dispatches
 
 ### Phase 1 tests — `chunkBuffer.test.ts`
 
-- `readBodyPositionAtFrac` at integer index returns p0 exactly.
-- `readBodyPositionAtFrac` at integer+1 returns p1 exactly.
-- `readBodyStateAtFrac` velocity at integer keyframe matches stored velocity exactly (Hermite degenerates correctly).
-- Hermite passes through endpoints with correct tangents (synthesize a two-keyframe buffer with known motion → verify intermediate value against analytical formula).
+- `readBodyPositionInto` at integer index returns p_i exactly (regression-protects the s=0 fast path).
+- `readBodyPositionInto` at integer + 0.5 with synthetic two-keyframe buffer (known p0, v0, p1, v1, dt) returns the analytical Hermite midpoint.
+- `readBodyStateInto` at integer keyframe returns stored velocity exactly.
+- `readBodyStateInto` at integer + 0.5 returns the Hermite analytic-derivative velocity.
+- Hermite endpoints check: at floatIdx=0 returns p0 + v0; at floatIdx=1 returns p1 + v1.
 - Boundary clamping: floatIdx > `totalTimesteps - 1` → returns last keyframe values; floatIdx < 0 → returns first.
-- Single-keyframe buffer: falls back gracefully to that keyframe's position (no Hermite).
+- Single-keyframe buffer: falls back gracefully to that keyframe's position + velocity (no Hermite, no out-of-bounds reads).
 
 ### Phase 1 verify criterion
 

--- a/frontend/src/app/components/chrome/TopStatusStrip.tsx
+++ b/frontend/src/app/components/chrome/TopStatusStrip.tsx
@@ -83,7 +83,7 @@ export function TopStatusStrip({
   const utcDate = isoToDateOrNull(utcKey);
   const jdStr = utcDate ? formatJD(julianDate(utcDate)) : "—";
 
-  const buffered = Math.max(0, total - idx);
+  const buffered = Math.max(0, total - Math.floor(idx));
   const bufferedStr = buffered.toLocaleString("en-US");
 
   // Pulse the Sim setup CTA only until the user has run their first sim.

--- a/frontend/src/app/components/dev/DevPanel.tsx
+++ b/frontend/src/app/components/dev/DevPanel.tsx
@@ -73,7 +73,8 @@ export function DevPanel() {
 function DevMetrics() {
   const total = useSelector(selectTotalTimeSteps);
   const idx = useSelector(selectCurrentTimeStepIndex);
-  const remaining = Math.max(0, total - idx);
+  const idxInt = Math.floor(idx);
+  const remaining = Math.max(0, total - idxInt);
   const buffer = useSelector(selectChunkBuffer);
   // Cheap O(1) calc — no JSON.stringify or Blob construction. Includes the
   // positions Float64Array (totalTimesteps × bodyCount × 48 bytes) and the
@@ -87,7 +88,7 @@ function DevMetrics() {
     <section className="flex flex-col gap-1.5 border-t border-dashed border-white/[0.06] pt-2.5">
       <p className="eyebrow">CHUNK BUFFER</p>
       <Row k="Total steps" v={total.toLocaleString("en-US")} />
-      <Row k="Current step" v={idx.toLocaleString("en-US")} />
+      <Row k="Current step" v={idxInt.toLocaleString("en-US")} />
       <Row k="Remaining" v={remaining.toLocaleString("en-US")} />
       <Row k="Payload size" v={formatBytes(bytes)} />
       {buffer && (

--- a/frontend/src/app/components/scene/AnimationController.tsx
+++ b/frontend/src/app/components/scene/AnimationController.tsx
@@ -4,31 +4,28 @@ import { useFrame } from "@react-three/fiber";
 import { useEffect, useRef } from "react";
 import { useDispatch, useSelector, useStore } from "react-redux";
 import {
-  selectCurrentTimeStepIndex,
   selectIsPaused,
   selectSpeedMultiplier,
   setCurrentTimeStepIndex,
 } from "@/app/store/slices/SimulationSlice";
 import SimConstants from "@/app/constants/SimConstants";
 import { AppDispatch, RootState } from "@/app/store/Store";
-
-const FRAME_INTERVAL = 1 / SimConstants.FPS;
+import { computeNextIndex } from "@/app/utils/animationStep";
 
 const AnimationController = () => {
   const dispatch = useDispatch<AppDispatch>();
   const store = useStore<RootState>();
+  // Note: NOT subscribing to currentTimeStepIndex via useSelector — this
+  // component dispatches that value every frame, so a selector subscription
+  // would re-render every frame (the known offender flagged in
+  // frontend-render-loop.md). We read it imperatively from store.getState()
+  // inside useFrame instead.
   const isPaused = useSelector(selectIsPaused);
   const speedMultiplier = useSelector(selectSpeedMultiplier);
-  const currentTimeStepIndex = useSelector(selectCurrentTimeStepIndex);
 
-  const currentIndexRef = useRef(currentTimeStepIndex);
   const isPausedRef = useRef(isPaused);
   const speedMultiplierRef = useRef(speedMultiplier);
-  const accRef = useRef(0);
 
-  useEffect(() => {
-    currentIndexRef.current = currentTimeStepIndex;
-  }, [currentTimeStepIndex]);
   useEffect(() => {
     isPausedRef.current = isPaused;
   }, [isPaused]);
@@ -37,27 +34,22 @@ const AnimationController = () => {
   }, [speedMultiplier]);
 
   useFrame((_, delta) => {
-    accRef.current += delta;
-    if (accRef.current < FRAME_INTERVAL) return;
-    accRef.current = 0;
     if (isPausedRef.current) return;
 
-    const buffer = store.getState().simulation.chunkBuffer;
+    const state = store.getState();
+    const buffer = state.simulation.chunkBuffer;
     if (!buffer || buffer.totalTimesteps === 0) return;
 
-    const stepsToMove = Math.abs(speedMultiplierRef.current);
-    const direction = speedMultiplierRef.current > 0 ? 1 : -1;
-    const proposed = currentIndexRef.current + direction * stepsToMove;
-    // Clamp to [0, totalTimesteps - 1] so the playback head never outruns
-    // the buffer. Speed-aware prefetch keeps the buffer ahead so this clamp
-    // is rarely the limiting factor in practice — but it's the safety net.
-    const nextIndex = Math.max(
-      0,
-      Math.min(buffer.totalTimesteps - 1, proposed),
-    );
+    const currentIndex = state.simulation.timeState.currentTimeStepIndex;
+    const nextIndex = computeNextIndex({
+      currentIndex,
+      delta,
+      speedMultiplier: speedMultiplierRef.current,
+      fps: SimConstants.FPS,
+      totalTimesteps: buffer.totalTimesteps,
+    });
 
-    if (nextIndex !== currentIndexRef.current) {
-      currentIndexRef.current = nextIndex;
+    if (nextIndex !== currentIndex) {
       dispatch(setCurrentTimeStepIndex(nextIndex));
     }
   });

--- a/frontend/src/app/components/scene/Trail.tsx
+++ b/frontend/src/app/components/scene/Trail.tsx
@@ -120,8 +120,14 @@ const Trail: React.FC<TrailProps> = ({
     }
 
     const length = Math.min(MAX_TRAIL_POINTS, getDevSettings().trailLength);
-    const start = Math.max(0, currentTimeStepIndex - length);
-    const end = Math.min(currentTimeStepIndex, buffer.totalTimesteps - 1);
+    // Floor the current index for the tail loop. Trail renders *historical*
+    // keyframes — integer indices semantically. Without this floor, every
+    // iteration of the loop below would hit the chunkBuffer's Hermite path
+    // (~30 mults/read) instead of the 4-read fast path. With ~5000 points × 9
+    // trails × FPS, the difference is measurable.
+    const idxFloor = Math.floor(currentTimeStepIndex);
+    const start = Math.max(0, idxFloor - length);
+    const end = Math.min(idxFloor, buffer.totalTimesteps - 1);
     const total = end - start;
 
     const bodyProps: CelestialBodyProperties | undefined =

--- a/frontend/src/app/store/chunkBuffer.test.ts
+++ b/frontend/src/app/store/chunkBuffer.test.ts
@@ -195,6 +195,51 @@ describe("readBodyStateInto", () => {
   });
 });
 
+describe("readBodyPositionInto — integer index (regression)", () => {
+  it("returns stored position exactly at integer keyframe", () => {
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      1, 2, 3, 10, 11, 12,
+      4, 5, 6, 13, 14, 15,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, 0, 0);
+    expect(out.x).toBe(1);
+    expect(out.y).toBe(2);
+    expect(out.z).toBe(3);
+
+    readBodyPositionInto(out, buf, 1, 0);
+    expect(out.x).toBe(4);
+    expect(out.y).toBe(5);
+    expect(out.z).toBe(6);
+  });
+});
+
+describe("readBodyStateInto — integer index (regression)", () => {
+  it("returns stored position and velocity exactly at integer keyframe", () => {
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      1, 2, 3, 10, 11, 12,
+      4, 5, 6, 13, 14, 15,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const outPos = new THREE.Vector3();
+    const outVel = new THREE.Vector3();
+    readBodyStateInto(outPos, outVel, buf, 1, 0);
+    expect(outPos.x).toBe(4);
+    expect(outPos.y).toBe(5);
+    expect(outPos.z).toBe(6);
+    expect(outVel.x).toBe(13);
+    expect(outVel.y).toBe(14);
+    expect(outVel.z).toBe(15);
+  });
+});
+
 describe("getTimestamp / getTimestampAsIsoString", () => {
   it("returns raw millis as BigInt and ISO string for a given timestep", () => {
     const buf = createChunkBuffer(["A"], 5);

--- a/frontend/src/app/store/chunkBuffer.test.ts
+++ b/frontend/src/app/store/chunkBuffer.test.ts
@@ -227,6 +227,23 @@ describe("readBodyPositionInto — fractional index (Hermite)", () => {
     readBodyPositionInto(out, buf, 0.5, 0);
     expect(out.x).toBeCloseTo(0.5, 10);
   });
+
+  it("scales Hermite tangent terms by dt correctly at non-unit interval", () => {
+    // dt = 0.5s. Constant velocity = 2 m/s in x.
+    // Linear motion over 0.5s covers 1 m: p0=(0,0,0) → p1=(1,0,0) with v0=v1=(2,0,0).
+    // Midpoint (s=0.5) should be (0.5, 0, 0).
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      0, 0, 0, 2, 0, 0,
+      1, 0, 0, 2, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 500n]); // dt = 0.5s
+    appendChunk(buf, positions, timestamps, 2);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, 0.5, 0);
+    expect(out.x).toBeCloseTo(0.5, 10);
+  });
 });
 
 describe("readBodyStateInto — fractional index (Hermite)", () => {
@@ -356,6 +373,26 @@ describe("readBodyStateInto — integer index (regression)", () => {
     expect(outVel.x).toBe(13);
     expect(outVel.y).toBe(14);
     expect(outVel.z).toBe(15);
+  });
+
+  it("returns first-keyframe position and velocity when floatIdx is exactly 0", () => {
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      1, 2, 3, 10, 11, 12,
+      4, 5, 6, 13, 14, 15,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const outPos = new THREE.Vector3();
+    const outVel = new THREE.Vector3();
+    readBodyStateInto(outPos, outVel, buf, 0, 0);
+    expect(outPos.x).toBe(1);
+    expect(outPos.y).toBe(2);
+    expect(outPos.z).toBe(3);
+    expect(outVel.x).toBe(10);
+    expect(outVel.y).toBe(11);
+    expect(outVel.z).toBe(12);
   });
 });
 

--- a/frontend/src/app/store/chunkBuffer.test.ts
+++ b/frontend/src/app/store/chunkBuffer.test.ts
@@ -267,6 +267,53 @@ describe("readBodyStateInto — fractional index (Hermite)", () => {
   });
 });
 
+describe("readBodyPositionInto — boundaries and edge cases", () => {
+  it("clamps floatIdx > totalTimesteps - 1 to last keyframe", () => {
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      1, 2, 3, 0, 0, 0,
+      4, 5, 6, 0, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, 999, 0);
+    expect(out.x).toBe(4);
+    expect(out.y).toBe(5);
+    expect(out.z).toBe(6);
+  });
+
+  it("clamps floatIdx < 0 to first keyframe", () => {
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      1, 2, 3, 0, 0, 0,
+      4, 5, 6, 0, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, -5, 0);
+    expect(out.x).toBe(1);
+    expect(out.y).toBe(2);
+    expect(out.z).toBe(3);
+  });
+
+  it("returns first-keyframe values for a single-keyframe buffer", () => {
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([1, 2, 3, 0, 0, 0]);
+    const timestamps = new BigInt64Array([0n]);
+    appendChunk(buf, positions, timestamps, 1);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, 0.5, 0);
+    expect(out.x).toBe(1);
+    expect(out.y).toBe(2);
+    expect(out.z).toBe(3);
+  });
+});
+
 describe("readBodyPositionInto — integer index (regression)", () => {
   it("returns stored position exactly at integer keyframe", () => {
     const buf = createChunkBuffer(["Earth"], 4);

--- a/frontend/src/app/store/chunkBuffer.test.ts
+++ b/frontend/src/app/store/chunkBuffer.test.ts
@@ -195,6 +195,40 @@ describe("readBodyStateInto", () => {
   });
 });
 
+describe("readBodyPositionInto — fractional index (Hermite)", () => {
+  it("interpolates position at midpoint via cubic Hermite", () => {
+    // Constant velocity → linear position; midpoint = (0.5, 0, 0).
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      0, 0, 0, 1, 0, 0,
+      1, 0, 0, 1, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, 0.5, 0);
+    expect(out.x).toBeCloseTo(0.5, 10);
+    expect(out.y).toBeCloseTo(0, 10);
+    expect(out.z).toBeCloseTo(0, 10);
+  });
+
+  it("interpolates non-linear motion correctly via Hermite cubic", () => {
+    // Zero tangents at both ends → smoothstep; midpoint = 0.5.
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      0, 0, 0, 0, 0, 0,
+      1, 0, 0, 0, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const out = new THREE.Vector3();
+    readBodyPositionInto(out, buf, 0.5, 0);
+    expect(out.x).toBeCloseTo(0.5, 10);
+  });
+});
+
 describe("readBodyPositionInto — integer index (regression)", () => {
   it("returns stored position exactly at integer keyframe", () => {
     const buf = createChunkBuffer(["Earth"], 4);

--- a/frontend/src/app/store/chunkBuffer.test.ts
+++ b/frontend/src/app/store/chunkBuffer.test.ts
@@ -229,6 +229,44 @@ describe("readBodyPositionInto — fractional index (Hermite)", () => {
   });
 });
 
+describe("readBodyStateInto — fractional index (Hermite)", () => {
+  it("interpolates position and velocity at midpoint via Hermite", () => {
+    // Constant velocity → linear position, vel constant.
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      0, 0, 0, 1, 0, 0,
+      1, 0, 0, 1, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const outPos = new THREE.Vector3();
+    const outVel = new THREE.Vector3();
+    readBodyStateInto(outPos, outVel, buf, 0.5, 0);
+    expect(outPos.x).toBeCloseTo(0.5, 10);
+    expect(outVel.x).toBeCloseTo(1, 10);
+  });
+
+  it("interpolates velocity correctly when endpoints differ", () => {
+    // p0=0, v0=0, p1=1, v1=0, dt=1. Smoothstep position.
+    // Velocity at s=0.5 = derivative wrt sim-time:
+    //   h00'(0.5)=-1.5, h01'(0.5)=1.5, h10'(0.5)=-0.25, h11'(0.5)=-0.25
+    //   vel = (-1.5·0 + 1.5·1)/1 + -0.25·0 + -0.25·0 = 1.5 m/s
+    const buf = createChunkBuffer(["Earth"], 4);
+    const positions = new Float64Array([
+      0, 0, 0, 0, 0, 0,
+      1, 0, 0, 0, 0, 0,
+    ]);
+    const timestamps = new BigInt64Array([0n, 1000n]);
+    appendChunk(buf, positions, timestamps, 2);
+
+    const outPos = new THREE.Vector3();
+    const outVel = new THREE.Vector3();
+    readBodyStateInto(outPos, outVel, buf, 0.5, 0);
+    expect(outVel.x).toBeCloseTo(1.5, 10);
+  });
+});
+
 describe("readBodyPositionInto — integer index (regression)", () => {
   it("returns stored position exactly at integer keyframe", () => {
     const buf = createChunkBuffer(["Earth"], 4);

--- a/frontend/src/app/store/chunkBuffer.ts
+++ b/frontend/src/app/store/chunkBuffer.ts
@@ -209,20 +209,98 @@ export function readBodyPositionInto(
   out.z = h00 * p0z + h10 * dt * v0z + h01 * p1z + h11 * dt * v1z;
 }
 
+// Caller provides both output Vector3s — never allocates per call.
+//
+// floatIdx ∈ [0, totalTimesteps - 1]. Integer values short-circuit to
+// direct typed-array reads. Fractional values perform cubic Hermite for
+// position (using stored velocities as tangents) AND its analytic
+// derivative for velocity. Velocity at integer keyframes equals the
+// stored value exactly; velocity at fractional indices is consistent
+// with the Hermite-interpolated position.
 export function readBodyStateInto(
   outPos: ThreeVector3,
   outVel: ThreeVector3,
   buffer: ChunkBuffer,
-  timestepIdx: number,
+  floatIdx: number,
   bodyIdx: number,
 ): void {
-  const base = timestepIdx * buffer.bodyCount * 6 + bodyIdx * 6;
-  outPos.x = buffer.positions[base];
-  outPos.y = buffer.positions[base + 1];
-  outPos.z = buffer.positions[base + 2];
-  outVel.x = buffer.positions[base + 3];
-  outVel.y = buffer.positions[base + 4];
-  outVel.z = buffer.positions[base + 5];
+  if (floatIdx <= 0 || buffer.totalTimesteps <= 1) {
+    const base = 0 * buffer.bodyCount * 6 + bodyIdx * 6;
+    outPos.x = buffer.positions[base];
+    outPos.y = buffer.positions[base + 1];
+    outPos.z = buffer.positions[base + 2];
+    outVel.x = buffer.positions[base + 3];
+    outVel.y = buffer.positions[base + 4];
+    outVel.z = buffer.positions[base + 5];
+    return;
+  }
+  if (floatIdx >= buffer.totalTimesteps - 1) {
+    const base =
+      (buffer.totalTimesteps - 1) * buffer.bodyCount * 6 + bodyIdx * 6;
+    outPos.x = buffer.positions[base];
+    outPos.y = buffer.positions[base + 1];
+    outPos.z = buffer.positions[base + 2];
+    outVel.x = buffer.positions[base + 3];
+    outVel.y = buffer.positions[base + 4];
+    outVel.z = buffer.positions[base + 5];
+    return;
+  }
+
+  const i0 = Math.floor(floatIdx);
+  const s = floatIdx - i0;
+
+  if (s === 0) {
+    const base = i0 * buffer.bodyCount * 6 + bodyIdx * 6;
+    outPos.x = buffer.positions[base];
+    outPos.y = buffer.positions[base + 1];
+    outPos.z = buffer.positions[base + 2];
+    outVel.x = buffer.positions[base + 3];
+    outVel.y = buffer.positions[base + 4];
+    outVel.z = buffer.positions[base + 5];
+    return;
+  }
+
+  const stride = buffer.bodyCount * 6;
+  const base0 = i0 * stride + bodyIdx * 6;
+  const base1 = base0 + stride;
+
+  const dtMs = Number(buffer.timestamps[i0 + 1] - buffer.timestamps[i0]);
+  const dt = dtMs / 1000;
+
+  const s2 = s * s;
+  const s3 = s2 * s;
+
+  const h00 = 2 * s3 - 3 * s2 + 1;
+  const h10 = s3 - 2 * s2 + s;
+  const h01 = -2 * s3 + 3 * s2;
+  const h11 = s3 - s2;
+
+  const dh00 = 6 * s2 - 6 * s;
+  const dh10 = 3 * s2 - 4 * s + 1;
+  const dh01 = -6 * s2 + 6 * s;
+  const dh11 = 3 * s2 - 2 * s;
+  const invDt = 1 / dt;
+
+  const p0x = buffer.positions[base0];
+  const p0y = buffer.positions[base0 + 1];
+  const p0z = buffer.positions[base0 + 2];
+  const v0x = buffer.positions[base0 + 3];
+  const v0y = buffer.positions[base0 + 4];
+  const v0z = buffer.positions[base0 + 5];
+  const p1x = buffer.positions[base1];
+  const p1y = buffer.positions[base1 + 1];
+  const p1z = buffer.positions[base1 + 2];
+  const v1x = buffer.positions[base1 + 3];
+  const v1y = buffer.positions[base1 + 4];
+  const v1z = buffer.positions[base1 + 5];
+
+  outPos.x = h00 * p0x + h10 * dt * v0x + h01 * p1x + h11 * dt * v1x;
+  outPos.y = h00 * p0y + h10 * dt * v0y + h01 * p1y + h11 * dt * v1y;
+  outPos.z = h00 * p0z + h10 * dt * v0z + h01 * p1z + h11 * dt * v1z;
+
+  outVel.x = (dh00 * p0x + dh01 * p1x) * invDt + dh10 * v0x + dh11 * v1x;
+  outVel.y = (dh00 * p0y + dh01 * p1y) * invDt + dh10 * v0y + dh11 * v1y;
+  outVel.z = (dh00 * p0z + dh01 * p1z) * invDt + dh10 * v0z + dh11 * v1z;
 }
 
 export function getTimestamp(buffer: ChunkBuffer, timestepIdx: number): bigint {

--- a/frontend/src/app/store/chunkBuffer.ts
+++ b/frontend/src/app/store/chunkBuffer.ts
@@ -140,8 +140,9 @@ export function appendChunk(
 // to be called inside useFrame at FPS rate.
 //
 // floatIdx ∈ [0, totalTimesteps - 1]. Integer values short-circuit to a
-// direct typed-array read (zero perf cost; preserves existing s=0 behavior
-// for callers like Trail's tail loop). Fractional values invoke cubic
+// direct typed-array read after three cheap guard comparisons — minimal
+// branch overhead, preserves existing behavior for callers like Trail's
+// tail loop that pass integer indices. Fractional values invoke cubic
 // Hermite between floor(floatIdx) and floor(floatIdx) + 1, using the stored
 // velocities as exact tangents and per-keyframe timestamps for the interval.
 export function readBodyPositionInto(
@@ -151,7 +152,7 @@ export function readBodyPositionInto(
   bodyIdx: number,
 ): void {
   if (floatIdx <= 0 || buffer.totalTimesteps <= 1) {
-    const base = 0 * buffer.bodyCount * 6 + bodyIdx * 6;
+    const base = bodyIdx * 6;
     out.x = buffer.positions[base];
     out.y = buffer.positions[base + 1];
     out.z = buffer.positions[base + 2];
@@ -225,7 +226,7 @@ export function readBodyStateInto(
   bodyIdx: number,
 ): void {
   if (floatIdx <= 0 || buffer.totalTimesteps <= 1) {
-    const base = 0 * buffer.bodyCount * 6 + bodyIdx * 6;
+    const base = bodyIdx * 6;
     outPos.x = buffer.positions[base];
     outPos.y = buffer.positions[base + 1];
     outPos.z = buffer.positions[base + 2];

--- a/frontend/src/app/store/chunkBuffer.ts
+++ b/frontend/src/app/store/chunkBuffer.ts
@@ -138,16 +138,75 @@ export function appendChunk(
 
 // Caller provides the output Vector3 — never allocates per call. Designed
 // to be called inside useFrame at FPS rate.
+//
+// floatIdx ∈ [0, totalTimesteps - 1]. Integer values short-circuit to a
+// direct typed-array read (zero perf cost; preserves existing s=0 behavior
+// for callers like Trail's tail loop). Fractional values invoke cubic
+// Hermite between floor(floatIdx) and floor(floatIdx) + 1, using the stored
+// velocities as exact tangents and per-keyframe timestamps for the interval.
 export function readBodyPositionInto(
   out: ThreeVector3,
   buffer: ChunkBuffer,
-  timestepIdx: number,
+  floatIdx: number,
   bodyIdx: number,
 ): void {
-  const base = timestepIdx * buffer.bodyCount * 6 + bodyIdx * 6;
-  out.x = buffer.positions[base];
-  out.y = buffer.positions[base + 1];
-  out.z = buffer.positions[base + 2];
+  if (floatIdx <= 0 || buffer.totalTimesteps <= 1) {
+    const base = 0 * buffer.bodyCount * 6 + bodyIdx * 6;
+    out.x = buffer.positions[base];
+    out.y = buffer.positions[base + 1];
+    out.z = buffer.positions[base + 2];
+    return;
+  }
+  if (floatIdx >= buffer.totalTimesteps - 1) {
+    const base =
+      (buffer.totalTimesteps - 1) * buffer.bodyCount * 6 + bodyIdx * 6;
+    out.x = buffer.positions[base];
+    out.y = buffer.positions[base + 1];
+    out.z = buffer.positions[base + 2];
+    return;
+  }
+
+  const i0 = Math.floor(floatIdx);
+  const s = floatIdx - i0;
+
+  if (s === 0) {
+    const base = i0 * buffer.bodyCount * 6 + bodyIdx * 6;
+    out.x = buffer.positions[base];
+    out.y = buffer.positions[base + 1];
+    out.z = buffer.positions[base + 2];
+    return;
+  }
+
+  const stride = buffer.bodyCount * 6;
+  const base0 = i0 * stride + bodyIdx * 6;
+  const base1 = base0 + stride;
+
+  const dtMs = Number(buffer.timestamps[i0 + 1] - buffer.timestamps[i0]);
+  const dt = dtMs / 1000;
+
+  const s2 = s * s;
+  const s3 = s2 * s;
+  const h00 = 2 * s3 - 3 * s2 + 1;
+  const h10 = s3 - 2 * s2 + s;
+  const h01 = -2 * s3 + 3 * s2;
+  const h11 = s3 - s2;
+
+  const p0x = buffer.positions[base0];
+  const p0y = buffer.positions[base0 + 1];
+  const p0z = buffer.positions[base0 + 2];
+  const v0x = buffer.positions[base0 + 3];
+  const v0y = buffer.positions[base0 + 4];
+  const v0z = buffer.positions[base0 + 5];
+  const p1x = buffer.positions[base1];
+  const p1y = buffer.positions[base1 + 1];
+  const p1z = buffer.positions[base1 + 2];
+  const v1x = buffer.positions[base1 + 3];
+  const v1y = buffer.positions[base1 + 4];
+  const v1z = buffer.positions[base1 + 5];
+
+  out.x = h00 * p0x + h10 * dt * v0x + h01 * p1x + h11 * dt * v1x;
+  out.y = h00 * p0y + h10 * dt * v0y + h01 * p1y + h11 * dt * v1y;
+  out.z = h00 * p0z + h10 * dt * v0z + h01 * p1z + h11 * dt * v1z;
 }
 
 export function readBodyStateInto(

--- a/frontend/src/app/utils/animationStep.test.ts
+++ b/frontend/src/app/utils/animationStep.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { computeNextIndex } from "./animationStep";
+
+describe("computeNextIndex", () => {
+  it("at speedMultiplier=1, FPS=60, delta=1/60s → moves 1 unit forward", () => {
+    const next = computeNextIndex({
+      currentIndex: 100,
+      delta: 1 / 60,
+      speedMultiplier: 1,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBeCloseTo(101, 10);
+  });
+
+  it("at speedMultiplier=2, doubles the step rate", () => {
+    const next = computeNextIndex({
+      currentIndex: 100,
+      delta: 1 / 60,
+      speedMultiplier: 2,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBeCloseTo(102, 10);
+  });
+
+  it("negative speedMultiplier moves backward", () => {
+    const next = computeNextIndex({
+      currentIndex: 100,
+      delta: 1 / 60,
+      speedMultiplier: -1,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBeCloseTo(99, 10);
+  });
+
+  it("clamps to upper bound at totalTimesteps - 1", () => {
+    const next = computeNextIndex({
+      currentIndex: 9_999.5,
+      delta: 1 / 60,
+      speedMultiplier: 100,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBe(9_999);
+  });
+
+  it("clamps to lower bound at 0", () => {
+    const next = computeNextIndex({
+      currentIndex: 0.5,
+      delta: 1 / 60,
+      speedMultiplier: -100,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBe(0);
+  });
+
+  it("returns fractional values for sub-frame motion", () => {
+    // At 144Hz with speedMultiplier=1, delta ≈ 1/144, expected step ≈ 60/144 ≈ 0.417
+    const next = computeNextIndex({
+      currentIndex: 0,
+      delta: 1 / 144,
+      speedMultiplier: 1,
+      fps: 60,
+      totalTimesteps: 10_000,
+    });
+    expect(next).toBeCloseTo(60 / 144, 6);
+  });
+});

--- a/frontend/src/app/utils/animationStep.ts
+++ b/frontend/src/app/utils/animationStep.ts
@@ -1,0 +1,28 @@
+// Pure helper for AnimationController's per-frame index update. Extracted
+// for unit-testability — AnimationController itself is tightly coupled to
+// R3F's useFrame and the redux store, but the math is just arithmetic +
+// clamping.
+//
+// The drive model is wall-clock-rate: per real-world second of elapsed
+// playback, the simulation advances `speedMultiplier * fps` keyframe units.
+// At fps=60 and speedMultiplier=1 this exactly matches the legacy
+// integer-step throttled behavior (one step per 1/60s frame). At higher
+// refresh rates, the per-frame step naturally shrinks below 1.0 — the
+// chunkBuffer reads will Hermite-interpolate.
+//
+// Output is a float; clamped to [0, totalTimesteps - 1].
+export interface ComputeNextIndexInput {
+  currentIndex: number;
+  delta: number; // seconds since last frame (from R3F useFrame)
+  speedMultiplier: number; // signed; magnitude scales rate, sign sets direction
+  fps: number; // nominal sim FPS — defines the "1 unit per frame" baseline
+  totalTimesteps: number; // upper-bound (clamp at totalTimesteps - 1)
+}
+
+export function computeNextIndex(input: ComputeNextIndexInput): number {
+  const { currentIndex, delta, speedMultiplier, fps, totalTimesteps } = input;
+  const proposed = currentIndex + delta * fps * speedMultiplier;
+  if (proposed < 0) return 0;
+  if (proposed > totalTimesteps - 1) return totalTimesteps - 1;
+  return proposed;
+}


### PR DESCRIPTION
## Summary

Phase 1 of three for issue #20 (cubic Hermite keyframe interpolation + backend thinning). This phase ships smoother animation between integration samples with **zero protocol change** — the wire format already carried per-keyframe state vectors (px, py, pz, vx, vy, vz) and timestamps; the frontend just wasn't using the velocities yet.

Includes spec + Phase 1 plan + implementation. Phase 2 (backend keyframe thinning) and Phase 3 (SimParams UI) follow in subsequent branches after this verifies.

### Implementation

- **`chunkBuffer.ts`** — `readBodyPositionInto` and `readBodyStateInto` widened to accept a float `floatIdx`. Integer values short-circuit to the existing direct typed-array read (zero-Hermite fast path, same code path Trail's tail iteration hits). Fractional values perform inline cubic Hermite using stored velocities as exact tangents (no estimation) and per-keyframe timestamps for the interval. `readBodyStateInto` also returns interpolated velocity via the analytic derivative — `OrbitPath`'s Keplerian fit sees a coherent (r, v) pair at any time.

- **`animationStep.ts`** (new) — pure helper `computeNextIndex({...})` returning `currentIndex + delta · fps · speedMultiplier`, clamped. Unit-testable; the drive model is wall-clock-rate so playback rate is now framerate-independent.

- **`AnimationController.tsx`** — rewired to use `computeNextIndex`. Drops the `FRAME_INTERVAL` accumulator (wall-clock driving is framerate-independent — throttle no longer needed) and the `useSelector` subscription on `currentTimeStepIndex` (a known render-cascade offender per `frontend-render-loop.md` — this component dispatches that value every frame). Reads imperatively via `store.getState()` inside `useFrame`.

- **`Trail.tsx`** — floors `currentTimeStepIndex` at the loop boundary so the historical-tail iteration stays integer-indexed and hits the chunkBuffer's `s === 0` fast path. Without this, every iteration of ~5000 points × 9 trails × 60+ fps would have hit full Hermite math.

- **`DevPanel.tsx` + `TopStatusStrip.tsx`** — `Math.floor` at display sites so "Current step" / "Remaining" / "buffered" don't render as "1,234.567".

Scene consumers `Sphere`, `OrbitPath`, `Reticle`, `GhostLabel`, `Camera`, `BodyCard`, and the `framePivot` helper required no changes — they transparently propagate `currentTimeStepIndex` (now float) into `readBody*Into`, which is precisely why widening was preferred over adding parallel `*AtFrac` functions. The `framePivot.ts` doc and the consumer audit table in the spec document this.

### Spec deviations / notes for review

- **`Camera.tsx` per-frame allocation cleanup (Plan Task 8) was a no-op** — the `new THREE.Vector3` calls in the file are all in `useRef` initializers or `useEffect`s (mount/dep-change), not in `useFrame`. The `frontend-render-loop.md` "known offenders" entry was stale; updated that rule file (gitignored — not in this PR).
- **Spec was amended mid-implementation** to widen existing functions instead of adding parallel `*AtFrac` ones (commit d8ece4a). Cleaner API surface, no consumer migrations.
- **Dispatch-frequency trade-off:** on high-refresh displays (144Hz+), AnimationController now dispatches `setCurrentTimeStepIndex` at the display refresh rate instead of the legacy 60Hz throttle. Chrome subscribers (`Timeline`, `TopStatusStrip`, `DevPanel`) re-render at higher frequency as a result. They're small components, so likely fine — but flagged here. Future remedy if it materializes as a problem: split the index into a scene-read mutable ref + a coarser-dispatched redux value.

### Files

- `frontend/src/app/store/chunkBuffer.ts` — Hermite math
- `frontend/src/app/store/chunkBuffer.test.ts` — +11 tests (26 total in file)
- `frontend/src/app/utils/animationStep.ts` — new helper
- `frontend/src/app/utils/animationStep.test.ts` — 6 tests
- `frontend/src/app/components/scene/AnimationController.tsx` — rewire
- `frontend/src/app/components/scene/Trail.tsx` — floor fix
- `frontend/src/app/components/dev/DevPanel.tsx` — display floor
- `frontend/src/app/components/chrome/TopStatusStrip.tsx` — display floor
- `docs/superpowers/specs/2026-05-15-hermite-keyframe-interpolation-design.md` — spec (all 3 phases)
- `docs/superpowers/plans/2026-05-15-hermite-phase-1-frontend-interpolation.md` — Phase 1 plan

## Test Plan

Automated verification (already run, all green):

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` — 124/124 tests pass across 12 files (includes 11 new chunkBuffer Hermite tests + 6 new animationStep tests)

Manual verification (please run before merging):

- [ ] Submit a default sim. Wait for first chunk to load.
- [ ] Play at speedMultiplier=1 — motion looks visibly smoother than master (no per-step stutter between integration samples)
- [ ] Steady-state FPS unchanged vs master under the same scene
- [ ] speedMultiplier +5 / -1 / paused — all work; smooth at all speeds
- [ ] Drag the scrubber — scene snaps correctly to scrubbed time
- [ ] Click a body to focus — camera follows smoothly through fractional time positions
- [ ] Body's orbit path stays stable through animation (Hermite-interpolated velocity → Keplerian fit doesn't wobble)
- [ ] Trail head sits exactly on the body, no lag/jump; trail body looks identical to master
- [ ] Toggle helio ↔ geo display frame — Earth pivots correctly, no jitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)