### PR TITLE
DP853 adaptive substep capture + chunk snapshot budget (#68)

### DIFF
--- a/backend/src/main/java/personal/spacesim/apis/controller/SimulationController.java
+++ b/backend/src/main/java/personal/spacesim/apis/controller/SimulationController.java
@@ -5,6 +5,7 @@ import org.orekit.time.TimeScalesFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +15,7 @@ import personal.spacesim.dtos.SimulationChunkRequest;
 import personal.spacesim.dtos.SimulationRequestDTO;
 import personal.spacesim.dtos.SimulationResponseDTO;
 import personal.spacesim.services.SimulationSessionService;
+import personal.spacesim.simulation.exception.ChunkSnapshotBudgetExceededException;
 
 import java.util.List;
 
@@ -148,6 +150,28 @@ public class SimulationController {
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .body(compressedData);
+    }
+
+    /**
+     * Surfaces {@link ChunkSnapshotBudgetExceededException} as 422
+     * Unprocessable Entity. The user's request was syntactically valid but
+     * the dynamics demand more keyframes than a single chunk can hold —
+     * the client should prompt the user to coarsen settings rather than
+     * retry. The async precompute path wraps the throw in
+     * {@code RuntimeException}, so also unwrap one level.
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<String> handleChunkBudgetExceeded(RuntimeException ex) {
+        Throwable t = ex;
+        if (!(t instanceof ChunkSnapshotBudgetExceededException) && t.getCause() != null) {
+            t = t.getCause();
+        }
+        if (t instanceof ChunkSnapshotBudgetExceededException budgetEx) {
+            logger.warn("Chunk snapshot budget exceeded: {}", budgetEx.getMessage());
+            return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                    .body(budgetEx.getMessage());
+        }
+        throw ex;
     }
 
 }

--- a/backend/src/main/java/personal/spacesim/constants/SimulationLimits.java
+++ b/backend/src/main/java/personal/spacesim/constants/SimulationLimits.java
@@ -17,4 +17,21 @@ public final class SimulationLimits {
      * even with cubic interpolation.
      */
     public static final int MAX_KEYFRAMES_PER_KEPT = 100;
+
+    /**
+     * Absolute ceiling on snapshots a single chunk may emit before
+     * {@code Simulation.run()} throws
+     * {@code ChunkSnapshotBudgetExceededException}. Bounds wire size when
+     * DP853's adaptive substep capture surfaces dense bursts of keyframes
+     * during close encounters or chaotic scenarios.
+     *
+     * <p>Set at 2× the Euler K=1 baseline (10001) so DP853 can layer
+     * intermediate substeps on top of the regular external-step keyframes
+     * without tripping under normal solar-system loads. Wire-size budget
+     * scales accordingly: ~20000 × ~10 bodies × ~50 B compressed ≈ 10 MB
+     * worst case, vs the rate limiter's nominal 4 MB sizing — acceptable
+     * because the ceiling is only approached for chaotic / close-encounter
+     * scenarios where the dense resolution is the feature.
+     */
+    public static final int MAX_SNAPSHOTS_PER_CHUNK = 20_000;
 }

--- a/backend/src/main/java/personal/spacesim/simulation/Simulation.java
+++ b/backend/src/main/java/personal/spacesim/simulation/Simulation.java
@@ -8,6 +8,7 @@ import org.orekit.time.AbsoluteDate;
 import personal.spacesim.constants.PhysicsConstants;
 import personal.spacesim.simulation.body.CelestialBodySnapshot;
 import personal.spacesim.simulation.body.CelestialBodyWrapper;
+import personal.spacesim.simulation.exception.ChunkSnapshotBudgetExceededException;
 import personal.spacesim.simulation.state.GlobalState;
 import personal.spacesim.simulation.state.NBodyDerivatives;
 import personal.spacesim.utils.math.integrators.Integrator;
@@ -76,6 +77,14 @@ public class Simulation {
      */
     private final int sunIndex;
 
+    /**
+     * Hard ceiling on snapshots a single {@link #run()} invocation may
+     * emit before throwing {@link ChunkSnapshotBudgetExceededException}.
+     * Bounds wire size when DP853's adaptive substep capture fires dense
+     * bursts of keyframes during close encounters or chaotic scenarios.
+     */
+    private final int maxSnapshotsPerChunk;
+
     public Simulation(
             String sessionID,
             List<CelestialBodyWrapper> celestialBodies,
@@ -83,7 +92,8 @@ public class Simulation {
             Integrator integrator,
             AbsoluteDate simStartDate,
             String timeStepUnit,
-            int keyframesPerKept
+            int keyframesPerKept,
+            int maxSnapshotsPerChunk
     ) {
         this.sessionID = sessionID;
         this.frame = frame;
@@ -93,6 +103,7 @@ public class Simulation {
         this.simCurrentDate = simStartDate;
         this.timeStepUnit = timeStepUnit;
         this.keyframesPerKept = keyframesPerKept;
+        this.maxSnapshotsPerChunk = maxSnapshotsPerChunk;
         this.derivatives = NBodyDerivatives.forBodies(celestialBodies);
 
         // Pack initial wrapper state into the buffer once. After this, the
@@ -115,8 +126,15 @@ public class Simulation {
         this.sunIndex = sunIdx;
     }
 
+    /**
+     * Captured at the top of {@link #update()} so the substep handler can
+     * map Hipparchus's per-step relative times back into absolute dates.
+     */
+    private AbsoluteDate stepStartDate;
+
     private void update() {
         double deltaTimeSeconds = convertTimeStep(timeStepUnit);
+        stepStartDate = simCurrentDate;
         simCurrentDate = simCurrentDate.shiftedBy(deltaTimeSeconds);
 
         integrator.stepInto(nextStateBuffer, currentStateBuffer, deltaTimeSeconds, derivatives);
@@ -132,24 +150,53 @@ public class Simulation {
         long startTime = System.nanoTime();
         Map<AbsoluteDate, List<CelestialBodySnapshot>> results = new LinkedHashMap<>();
 
-        // Initial frame is always kept (step 0). Only on the first chunk.
-        if (!hasEmittedInitialFrame) {
-            results.put(simCurrentDate, snapshotFromState());
-            hasEmittedInitialFrame = true;
-            nextKeptAtStep = keyframesPerKept;
-        }
-
-        int currentTimeStep = 0;
-        while (currentTimeStep < TIMESTEPS_TO_RUN) {
-            update();
-            globalStepCount++;
-            // Single integer compare — K=1 path is identical to today
-            // (true every step, snapshot kept every step).
-            if (globalStepCount >= nextKeptAtStep) {
-                results.put(simCurrentDate, snapshotFromState());
-                nextKeptAtStep += keyframesPerKept;
+        // Adaptive-integrator substep capture: fires inside stepInto() for
+        // every accepted intermediate substep, emitting an extra keyframe
+        // at the substep's absolute time. Fixed-step integrators no-op.
+        integrator.setSubstepHandler((relativeTime, substepState) -> {
+            if (results.size() >= maxSnapshotsPerChunk) {
+                throw new ChunkSnapshotBudgetExceededException(
+                        "Chunk snapshot budget of " + maxSnapshotsPerChunk
+                                + " exceeded — dynamics are too stiff for the current "
+                                + "chunk parameters. Try a coarser keyframesPerKept, a "
+                                + "smaller timeStep unit, or a simpler body set.");
             }
-            currentTimeStep++;
+            results.put(stepStartDate.shiftedBy(relativeTime),
+                    snapshotFromState(substepState));
+        });
+
+        try {
+            // Initial frame is always kept (step 0). Only on the first chunk.
+            if (!hasEmittedInitialFrame) {
+                results.put(simCurrentDate, snapshotFromState(currentStateBuffer));
+                hasEmittedInitialFrame = true;
+                nextKeptAtStep = keyframesPerKept;
+            }
+
+            int currentTimeStep = 0;
+            while (currentTimeStep < TIMESTEPS_TO_RUN) {
+                update();
+                globalStepCount++;
+                // Single integer compare — K=1 path is identical to today
+                // (true every step, snapshot kept every step).
+                if (globalStepCount >= nextKeptAtStep) {
+                    if (results.size() >= maxSnapshotsPerChunk) {
+                        throw new ChunkSnapshotBudgetExceededException(
+                                "Chunk snapshot budget of " + maxSnapshotsPerChunk
+                                        + " exceeded at external step " + globalStepCount
+                                        + " — try a coarser keyframesPerKept or smaller "
+                                        + "timeStep unit.");
+                    }
+                    results.put(simCurrentDate, snapshotFromState(currentStateBuffer));
+                    nextKeptAtStep += keyframesPerKept;
+                }
+                currentTimeStep++;
+            }
+        } finally {
+            // Clear so a subsequent run() on this Simulation starts clean —
+            // and so the captured `results` reference does not outlive this
+            // chunk via the integrator's retained handler field.
+            integrator.setSubstepHandler(null);
         }
 
         long endTime = System.nanoTime();
@@ -162,14 +209,17 @@ public class Simulation {
     }
 
     /**
-     * Build a snapshot list directly from {@link #currentStateBuffer}.
+     * Build a snapshot list directly from the given flat state vector.
      * Sun-relative shifting (so the rendered Sun stays anchored at origin)
      * is done component-wise on primitive doubles — only the final two
      * Vector3D constructions inside each {@link CelestialBodySnapshot} are
      * unavoidable, since the snapshot record is the public wire format.
+     *
+     * <p>The state argument lets external-step keyframes use the live
+     * {@code currentStateBuffer} while substep callbacks can pass through
+     * Hipparchus's transient interpolator state directly.
      */
-    private List<CelestialBodySnapshot> snapshotFromState() {
-        double[] data = currentStateBuffer;
+    private List<CelestialBodySnapshot> snapshotFromState(double[] data) {
         double sunX = 0, sunY = 0, sunZ = 0;
         double sunVx = 0, sunVy = 0, sunVz = 0;
         if (sunIndex >= 0) {

--- a/backend/src/main/java/personal/spacesim/simulation/SimulationFactory.java
+++ b/backend/src/main/java/personal/spacesim/simulation/SimulationFactory.java
@@ -4,6 +4,7 @@ import org.orekit.frames.Frame;
 import org.orekit.time.AbsoluteDate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import personal.spacesim.constants.SimulationLimits;
 import personal.spacesim.simulation.body.CelestialBodyWrapper;
 import personal.spacesim.simulation.body.CelestialBodyWrapperFactory;
 import personal.spacesim.simulation.frame.CustomFrameFactory;
@@ -39,6 +40,26 @@ public class SimulationFactory {
             String timeStepUnit,
             int keyframesPerKept
     ) {
+        return createSimulation(sessionID, celestialBodyNames, frameStr, integratorStr,
+                simStartDate, timeStepUnit, keyframesPerKept,
+                SimulationLimits.MAX_SNAPSHOTS_PER_CHUNK);
+    }
+
+    /**
+     * Test/internal overload taking an explicit chunk snapshot budget.
+     * Production paths go through the single-arity overload above so the
+     * budget stays a single source of truth in {@link SimulationLimits}.
+     */
+    public Simulation createSimulation(
+            String sessionID,
+            List<String> celestialBodyNames,
+            String frameStr,
+            String integratorStr,
+            AbsoluteDate simStartDate,
+            String timeStepUnit,
+            int keyframesPerKept,
+            int maxSnapshotsPerChunk
+    ) {
 
         // using singleton DI instead of static method
         Frame frame = customFrameFactory.createFrame(frameStr);
@@ -57,7 +78,8 @@ public class SimulationFactory {
                 integrator,
                 simStartDate,
                 timeStepUnit,
-                keyframesPerKept
+                keyframesPerKept,
+                maxSnapshotsPerChunk
         );
     }
 }

--- a/backend/src/main/java/personal/spacesim/simulation/exception/ChunkSnapshotBudgetExceededException.java
+++ b/backend/src/main/java/personal/spacesim/simulation/exception/ChunkSnapshotBudgetExceededException.java
@@ -1,0 +1,23 @@
+package personal.spacesim.simulation.exception;
+
+/**
+ * Thrown by {@code Simulation.run()} when an adaptive integrator's
+ * substep capture would push the chunk's snapshot count past the
+ * configured {@code MAX_SNAPSHOTS_PER_CHUNK}.
+ *
+ * <p>Signals dynamic stiffness exceeds what the current chunk parameters
+ * can express within the wire budget — typically a close encounter or a
+ * contrived chaotic scenario. The simulation is left in an indeterminate
+ * state for the failing chunk; the session-level integrator state is no
+ * longer trustworthy and the session should be terminated.
+ *
+ * <p>Surfaced at the HTTP boundary as a 422 Unprocessable Entity so the
+ * client can prompt the user to coarsen {@code dt}, raise
+ * {@code keyframesPerKept}, or simplify the body set.
+ */
+public class ChunkSnapshotBudgetExceededException extends RuntimeException {
+
+    public ChunkSnapshotBudgetExceededException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/personal/spacesim/utils/math/integrators/DP853Integrator.java
+++ b/backend/src/main/java/personal/spacesim/utils/math/integrators/DP853Integrator.java
@@ -1,8 +1,11 @@
 package personal.spacesim.utils.math.integrators;
 
 import org.hipparchus.ode.ODEState;
+import org.hipparchus.ode.ODEStateAndDerivative;
 import org.hipparchus.ode.OrdinaryDifferentialEquation;
 import org.hipparchus.ode.nonstiff.DormandPrince853Integrator;
+import org.hipparchus.ode.sampling.ODEStateInterpolator;
+import org.hipparchus.ode.sampling.ODEStepHandler;
 import personal.spacesim.simulation.state.NBodyDerivatives;
 
 /**
@@ -54,6 +57,20 @@ public final class DP853Integrator implements Integrator {
     private double[] derivScratch;
 
     /**
+     * Optional callback receiving each accepted intermediate substep.
+     * Read inside Hipparchus's step handler — null = nothing to forward.
+     */
+    private SubstepHandler substepHandler;
+
+    /**
+     * Set at the top of each {@link #stepInto} call so the step handler
+     * can distinguish the final substep (which lands exactly at {@code dt})
+     * from intermediates. The final substep is suppressed because it
+     * duplicates the endpoint the simulation loop emits separately.
+     */
+    private double currentStepDt;
+
+    /**
      * Reused across steps. Holds {@link #currentDerivatives} and
      * {@link #derivScratch} via closure over the outer instance.
      */
@@ -70,12 +87,40 @@ public final class DP853Integrator implements Integrator {
         }
     };
 
+    public DP853Integrator() {
+        hipparchusIntegrator.addStepHandler(new ODEStepHandler() {
+            @Override
+            public void handleStep(ODEStateInterpolator interpolator) {
+                SubstepHandler h = substepHandler;
+                if (h == null) {
+                    return;
+                }
+                ODEStateAndDerivative end = interpolator.getCurrentState();
+                double t = end.getTime();
+                // The substep landing exactly at dt is the integration
+                // endpoint — the simulation loop emits a keyframe for it
+                // through the regular post-step path, so suppress here to
+                // avoid a duplicate at every external-step boundary.
+                if (t >= currentStepDt) {
+                    return;
+                }
+                h.onSubstep(t, end.getCompleteState());
+            }
+        });
+    }
+
+    @Override
+    public void setSubstepHandler(SubstepHandler handler) {
+        this.substepHandler = handler;
+    }
+
     @Override
     public void stepInto(double[] out, double[] state, double dt, NBodyDerivatives derivatives) {
         if (derivScratch == null || derivScratch.length != state.length) {
             derivScratch = new double[state.length];
         }
         currentDerivatives = derivatives;
+        currentStepDt = dt;
 
         ODEState start = new ODEState(0.0, state);
         ODEState end = hipparchusIntegrator.integrate(ode, start, dt);

--- a/backend/src/main/java/personal/spacesim/utils/math/integrators/Integrator.java
+++ b/backend/src/main/java/personal/spacesim/utils/math/integrators/Integrator.java
@@ -49,4 +49,18 @@ public sealed interface Integrator
         stepInto(result, state.data(), dt, derivatives);
         return new GlobalState(result, state.bodyCount());
     }
+
+    /**
+     * Register a {@link SubstepHandler} to receive accepted intermediate
+     * substeps for each subsequent {@code stepInto} call. Pass {@code null}
+     * to clear.
+     *
+     * <p>Default is a no-op: fixed-step integrators (Euler, RK4) take a
+     * single step per call and have no intermediate substeps to expose.
+     * Only {@link DP853Integrator} overrides this to delegate Hipparchus's
+     * step-handler events.
+     */
+    default void setSubstepHandler(SubstepHandler handler) {
+        // no-op for fixed-step integrators
+    }
 }

--- a/backend/src/main/java/personal/spacesim/utils/math/integrators/SubstepHandler.java
+++ b/backend/src/main/java/personal/spacesim/utils/math/integrators/SubstepHandler.java
@@ -1,0 +1,32 @@
+package personal.spacesim.utils.math.integrators;
+
+/**
+ * Callback for accepted intermediate substeps from an adaptive integrator.
+ *
+ * <p>Today only {@link DP853Integrator} fires substep events — Hipparchus's
+ * adaptive solver subdivides each {@code stepInto} call as needed to keep
+ * local error within tolerance, and surfaces every accepted subdivision
+ * through this hook. Fixed-step integrators (Euler, RK4) never invoke this.
+ *
+ * <p>The final substep at {@code t == dt} is intentionally NOT delivered:
+ * that point coincides with the step endpoint that the simulation loop
+ * emits on its own, so suppressing it here avoids a duplicate keyframe at
+ * every external-step boundary. Implementations therefore only see
+ * intermediate substeps, with relative times strictly in {@code (0, dt)}.
+ *
+ * <p>The {@code substepState} array is owned by the integrator — callbacks
+ * must read or copy what they need before returning, not retain a reference.
+ */
+@FunctionalInterface
+public interface SubstepHandler {
+
+    /**
+     * @param relativeTimeSec time of this substep relative to the start of
+     *                        the current {@code stepInto} call, in seconds
+     *                        ({@code 0 < relativeTimeSec < dt})
+     * @param substepState    flat state vector at this substep (same layout
+     *                        as {@code GlobalState.data()}); transient — do
+     *                        not retain after the callback returns
+     */
+    void onSubstep(double relativeTimeSec, double[] substepState);
+}

--- a/backend/src/test/java/personal/spacesim/simulation/SimulationTest.java
+++ b/backend/src/test/java/personal/spacesim/simulation/SimulationTest.java
@@ -12,6 +12,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import personal.spacesim.simulation.body.CelestialBodySnapshot;
 
+import personal.spacesim.simulation.exception.ChunkSnapshotBudgetExceededException;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
@@ -22,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Pins {@link Simulation#run()}'s keyframe-thinning emission contract.
@@ -61,6 +65,19 @@ class SimulationTest {
                 new AbsoluteDate("2024-01-01T00:00:00.000", TimeScalesFactory.getUTC()),
                 "seconds",
                 keyframesPerKept
+        );
+    }
+
+    private Simulation newDP853Sim(String sessionSuffix, int keyframesPerKept, int maxSnapshotsPerChunk) {
+        return simulationFactory.createSimulation(
+                "test-dp853-" + sessionSuffix,
+                List.of("Sun", "Earth"),
+                "ICRF",
+                "DP853",
+                new AbsoluteDate("2024-01-01T00:00:00.000", TimeScalesFactory.getUTC()),
+                "weeks",
+                keyframesPerKept,
+                maxSnapshotsPerChunk
         );
     }
 
@@ -119,6 +136,31 @@ class SimulationTest {
         // entry than Chunk 1 at the same K.
         assertEquals(2500, chunk2.size(),
                 "Second chunk should emit only thinned keyframes, no initial");
+    }
+
+    /**
+     * With DP853 + dt=1 week (>{@code MAX_STEP}=1 day), Hipparchus must
+     * accept ≥6 intermediate substeps per external step. Each of those
+     * intermediates is emitted alongside the regular external-step
+     * keyframes, so the chunk must contain strictly more than the today
+     * fixed count of 10001 (1 initial + 10000 external).
+     */
+    @Test
+    void dp853ChunkContainsIntermediateSubsteps() {
+        Simulation sim = newDP853Sim("substeps", 1, 10_000_000);
+
+        Map<AbsoluteDate, List<CelestialBodySnapshot>> chunk = sim.run();
+
+        assertTrue(chunk.size() > 10_001,
+                "DP853 chunk should contain intermediate substeps in addition "
+                        + "to the 10001 external-step keyframes; got " + chunk.size());
+    }
+
+    @Test
+    void exceedingSnapshotBudgetThrowsClearException() {
+        Simulation sim = newDP853Sim("budget", 1, 5);
+
+        assertThrows(ChunkSnapshotBudgetExceededException.class, sim::run);
     }
 
     private static AbsoluteDate firstKey(Map<AbsoluteDate, List<CelestialBodySnapshot>> m) {

--- a/backend/src/test/java/personal/spacesim/utils/math/integrators/DP853IntegratorTest.java
+++ b/backend/src/test/java/personal/spacesim/utils/math/integrators/DP853IntegratorTest.java
@@ -4,7 +4,12 @@ import org.junit.jupiter.api.Test;
 import personal.spacesim.simulation.state.GlobalState;
 import personal.spacesim.simulation.state.NBodyDerivatives;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DP853IntegratorTest {
 
@@ -57,5 +62,57 @@ class DP853IntegratorTest {
 
         assertEquals(0.0, data[0], 1e-12);
         assertEquals(1.0, data[3], 1e-12);
+    }
+
+    /**
+     * With dt of 7 days, Hipparchus's MAX_STEP=1 day cap forces the
+     * integrator to take at least 6 accepted substeps before the final one,
+     * so the substep handler must fire with strictly intermediate times.
+     */
+    @Test
+    void substepHandlerReceivesIntermediateAcceptedSubsteps() {
+        // Sun + Earth at perihelion-ish — enough gravity that DP853 doesn't
+        // race through, but not stiff enough to time out.
+        double mSun = 1.989e30;
+        double mEarth = 5.972e24;
+        double r = 1.496e11;
+        double v = 2.978e4;
+        NBodyDerivatives derivs = new NBodyDerivatives(new double[]{mSun, mEarth});
+        GlobalState state = new GlobalState(new double[]{
+                0, 0, 0, 0, 0, 0,
+                r, 0, 0, 0, v, 0,
+        }, 2);
+
+        DP853Integrator dp = new DP853Integrator();
+        List<Double> substepTimes = new ArrayList<>();
+        dp.setSubstepHandler((t, y) -> substepTimes.add(t));
+
+        double dt = 86400.0 * 7;
+        dp.step(state, dt, derivs);
+
+        assertFalse(substepTimes.isEmpty(),
+                "Substep handler must fire for dt > MAX_STEP");
+        for (double t : substepTimes) {
+            assertTrue(t > 0 && t < dt,
+                    "Substep time " + t + " must lie strictly within (0, " + dt + ")");
+        }
+        for (int i = 1; i < substepTimes.size(); i++) {
+            assertTrue(substepTimes.get(i) > substepTimes.get(i - 1),
+                    "Substep times must be monotonically increasing");
+        }
+    }
+
+    @Test
+    void substepHandlerNotCalledWhenUnset() {
+        NBodyDerivatives derivs = new NBodyDerivatives(new double[]{1.989e30, 5.972e24});
+        GlobalState state = new GlobalState(new double[]{
+                0, 0, 0, 0, 0, 0,
+                1.496e11, 0, 0, 0, 2.978e4, 0,
+        }, 2);
+
+        // No handler registered. Should run without invoking anything.
+        new DP853Integrator().step(state, 86400.0 * 7, derivs);
+        // No assertion needed — if a stray callback were firing it'd NPE
+        // or surface in coverage. This test pins "absent handler = no work".
     }
 }


### PR DESCRIPTION
## Summary

- Exposes Hipparchus's accepted intermediate substeps as wire keyframes through a new `SubstepHandler` interface on `Integrator`. DP853 delegates Hipparchus step-handler events; Euler/RK4 keep the default no-op. The final substep at `t=dt` is filtered inside DP853 to avoid duplicating the external-step boundary.
- Adds `MAX_SNAPSHOTS_PER_CHUNK = 20000` (2× Euler K=1 baseline) and `ChunkSnapshotBudgetExceededException`, surfaced at the HTTP boundary as 422 with a clear "coarsen your parameters" message — fail loud rather than silently degrade resolution mid-chunk.

## Design notes flagged for review

- **Budget value**: discussion landed on 5000 assuming substeps would REPLACE external-step emissions. This implementation has substeps ADD to them so K thinning still works uniformly across integrator families — needed 2× the Euler K=1 baseline (10001) to avoid breaking existing behavior. **Update from byeon: even 20000 is too tight under generous settings; budget needs a separate revisit.**
- "DP853 + weeks" runs will trip the budget (~70k substeps for 10000 external steps).

## Test plan

- [x] `DP853IntegratorTest`: substep handler fires for intermediate substeps with `t < dt`; no-op when handler unset
- [x] `SimulationTest`: DP853+weeks chunk > 10001 frames (substeps captured); budget=5 with DP853 throws `ChunkSnapshotBudgetExceededException`
- [x] TDD red-green verified by temporarily disabling wiring/budget checks and observing meaningful failure
- [x] All 4 pre-existing Euler thinning tests unchanged (backward compat)
- [x] All 50 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)