### PR TITLE
Chunk optimisation: benchmark, design doc, Phase 1 (float32)

### DIFF
--- a/backend/src/main/java/personal/spacesim/utils/serializers/BinaryResponseSerializer.java
+++ b/backend/src/main/java/personal/spacesim/utils/serializers/BinaryResponseSerializer.java
@@ -23,13 +23,21 @@ import java.util.Map;
  *   per timestep:
  *     int64    timestamp (millis since UNIX epoch, UTC)
  *     per body (in header order):
- *       float64 × 6   (px, py, pz, vx, vy, vz)
+ *       float32 × 6   (px, py, pz, vx, vy, vz)
+ *
+ * Positions + velocities use float32 — ~7-decimal-digit precision is fine
+ * for visualisation (the Keplerian-element math is performed once per body
+ * card render, not in the integrator, so input precision dominates over
+ * derivative-amplified rounding). Halves raw per-timestep bytes.
  *
  * Body names + µ (standard gravitational parameter, m³/s²) are sent once in
- * the header; per-timestep payloads use header-order indexing. µ is needed
- * client-side to derive Keplerian orbital elements from (r, v) state vectors;
- * inlining it avoids a separate metadata fetch and is constant per session
- * so resending per chunk costs only bodyCount × 8 bytes (~80 B for 10 bodies).
+ * the header; per-timestep payloads use header-order indexing. µ stays
+ * float64 because it appears once per session per body (not per timestep)
+ * and the Keplerian derivation is sensitive to µ precision in a way the
+ * positions aren't. µ is needed client-side to derive Keplerian orbital
+ * elements from (r, v) state vectors; inlining it avoids a separate metadata
+ * fetch and is constant per session so resending per chunk costs only
+ * bodyCount × 8 bytes (~80 B for 10 bodies).
  *
  * Assumes a stable body order across timesteps within a chunk, which the
  * integrator guarantees.
@@ -61,7 +69,8 @@ public class BinaryResponseSerializer {
         }
 
         int timestepCount = data.size();
-        int perTimestepSize = 8 + bodyCount * 6 * 8; // timestamp + 6 doubles per body
+        // timestamp (int64) + 6 floats (float32) per body
+        int perTimestepSize = 8 + bodyCount * 6 * 4;
         int totalSize = headerSize + timestepCount * perTimestepSize;
 
         ByteBuffer buf = ByteBuffer.allocate(totalSize).order(ByteOrder.LITTLE_ENDIAN);
@@ -89,8 +98,8 @@ public class BinaryResponseSerializer {
             for (int i = 0; i < bodyCount; i++) {
                 Vector3D pos = snapshot.get(i).position();
                 Vector3D vel = snapshot.get(i).velocity();
-                buf.putDouble(pos.getX()).putDouble(pos.getY()).putDouble(pos.getZ());
-                buf.putDouble(vel.getX()).putDouble(vel.getY()).putDouble(vel.getZ());
+                buf.putFloat((float) pos.getX()).putFloat((float) pos.getY()).putFloat((float) pos.getZ());
+                buf.putFloat((float) vel.getX()).putFloat((float) vel.getY()).putFloat((float) vel.getZ());
             }
         }
 

--- a/backend/src/test/java/personal/spacesim/tools/ChunkSizeBenchmark.java
+++ b/backend/src/test/java/personal/spacesim/tools/ChunkSizeBenchmark.java
@@ -1,0 +1,134 @@
+package personal.spacesim.tools;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.orekit.time.AbsoluteDate;
+import org.orekit.time.TimeScalesFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import personal.spacesim.simulation.Simulation;
+import personal.spacesim.simulation.SimulationFactory;
+import personal.spacesim.simulation.body.CelestialBodySnapshot;
+import personal.spacesim.simulation.body.CelestialBodyWrapper;
+import personal.spacesim.utils.compressor.ZstdCompressor;
+import personal.spacesim.utils.serializers.BinaryResponseSerializer;
+
+/**
+ * One-off wire-size measurement harness for chunk bandwidth optimisation
+ * (todos #37 and #69).
+ *
+ * <p>Walks the realistic integrator × K matrix users actually encounter
+ * (full solar system, 10 bodies), runs the same serialize → zstd pipeline
+ * the controller uses, and prints per-scenario:
+ * <ul>
+ *   <li>snapshot count</li>
+ *   <li>raw bytes (post-serializer)</li>
+ *   <li>compressed bytes (post-zstd, includes the 4-byte length prefix)</li>
+ *   <li>compression ratio</li>
+ *   <li>bytes per snapshot (raw + compressed)</li>
+ *   <li>bytes per snapshot-body (the implicit unit in
+ *       {@code SimulationLimits.MAX_SNAPSHOTS_PER_CHUNK} docstring)</li>
+ * </ul>
+ *
+ * <p>Output is plain text on stdout — this is a measurement tool, not an
+ * assertion. The numbers feed the wire-size target decision before any
+ * format changes (float32, delta encoding) land.
+ *
+ * <p>The DP853 K=1 row uses an elevated snapshot budget so we can measure
+ * the worst-case substep burst rather than tripping
+ * {@code ChunkSnapshotBudgetExceededException} — exactly the design question
+ * todo #69 is about.
+ *
+ * <p>Disabled by default — runs only when {@code -Dchunk.benchmark=true}
+ * is passed, mirroring {@link IntegratorBenchmark}.
+ *
+ * <p>Run:
+ * <pre>
+ *   cd backend
+ *   ./mvnw test -Dtest=ChunkSizeBenchmark -Dchunk.benchmark=true
+ * </pre>
+ */
+@SpringBootTest
+@EnabledIfSystemProperty(named = "chunk.benchmark", matches = "true")
+class ChunkSizeBenchmark {
+
+    private static final List<String> BODIES = List.of(
+        "Sun", "Mercury", "Venus", "Earth", "Moon",
+        "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"
+    );
+    private static final String FRAME = "ICRF";
+    private static final String TIME_STEP_UNIT = "hours";
+
+    private record Scenario(String label, String integrator, int k, int snapshotBudget) {}
+
+    // Centered on what real users hit (per-integrator defaults from the
+    // Hermite work — Euler K=1, RK4 K=4, DP853 K=8). DP853 K=4 and K=1
+    // bracket the high-fidelity end; K=1 uses an elevated budget so we
+    // can measure the substep-burst worst case rather than throw.
+    private static final List<Scenario> SCENARIOS = List.of(
+        new Scenario("euler   K=1  (default)",        "euler", 1, 100_000),
+        new Scenario("rk4     K=4  (default)",        "rk4",   4, 100_000),
+        new Scenario("dp853   K=8  (default)",        "dp853", 8, 100_000),
+        new Scenario("dp853   K=4  (medium-high)",    "dp853", 4, 100_000),
+        new Scenario("dp853   K=1  (stress — substep worst case)", "dp853", 1, 100_000)
+    );
+
+    @Autowired private SimulationFactory simulationFactory;
+    @Autowired private BinaryResponseSerializer binaryResponseSerializer;
+    @Autowired private ZstdCompressor zstdCompressor;
+
+    @Test
+    void measure() {
+        AbsoluteDate startDate = new AbsoluteDate(2026, 1, 1, 0, 0, 0.0, TimeScalesFactory.getUTC());
+
+        System.out.println();
+        System.out.println("Chunk-size benchmark — 10 bodies, " + TIME_STEP_UNIT + " step, ICRF");
+        System.out.println("First-chunk measurement (post-initialise). Compressed bytes include the 4-byte length prefix.");
+        System.out.println();
+        System.out.printf("  %-44s %10s %12s %12s %8s %12s %12s%n",
+            "scenario", "snapshots", "raw KB", "zstd KB", "ratio", "B/snap", "B/snap·body");
+        System.out.println("  " + "-".repeat(112));
+
+        for (Scenario s : SCENARIOS) {
+            Simulation sim = simulationFactory.createSimulation(
+                "chunk-bench-" + s.integrator + "-K" + s.k,
+                BODIES, FRAME, s.integrator, startDate, TIME_STEP_UNIT,
+                s.k, s.snapshotBudget
+            );
+
+            Map<AbsoluteDate, List<CelestialBodySnapshot>> chunk = sim.run();
+
+            LinkedHashMap<String, Double> muByName = new LinkedHashMap<>();
+            for (CelestialBodyWrapper w : sim.getCelestialBodies()) {
+                muByName.put(w.getName(), w.getMu());
+            }
+
+            byte[] raw = binaryResponseSerializer.serialize(chunk, muByName);
+            byte[] compressed = zstdCompressor.compress(raw);
+
+            int snapshots = chunk.size();
+            int bodies = BODIES.size();
+            double ratio = (double) raw.length / compressed.length;
+            double bytesPerSnap = (double) compressed.length / snapshots;
+            double bytesPerSnapBody = bytesPerSnap / bodies;
+
+            System.out.printf("  %-44s %10d %12.1f %12.1f %8.2f %12.1f %12.2f%n",
+                s.label,
+                snapshots,
+                raw.length / 1024.0,
+                compressed.length / 1024.0,
+                ratio,
+                bytesPerSnap,
+                bytesPerSnapBody
+            );
+        }
+
+        System.out.println();
+        System.out.println("Target reference (todo #37): <1 MB compressed per chunk.");
+        System.out.println("Current MAX_SNAPSHOTS_PER_CHUNK = 20000 (todo #69).");
+        System.out.println();
+    }
+}

--- a/backend/src/test/java/personal/spacesim/utils/serializers/BinaryResponseSerializerTest.java
+++ b/backend/src/test/java/personal/spacesim/utils/serializers/BinaryResponseSerializerTest.java
@@ -113,14 +113,14 @@ class BinaryResponseSerializerTest {
 
         assertEquals(1, buf.getInt(), "timestepCount");
 
-        // Per-timestep
+        // Per-timestep — positions+velocities are float32 (small integers roundtrip exactly).
         assertEquals(expectedMillis, buf.getLong(), "timestamp millis");
         // Earth
-        assertEquals(1.0, buf.getDouble()); assertEquals(2.0, buf.getDouble()); assertEquals(3.0, buf.getDouble());
-        assertEquals(4.0, buf.getDouble()); assertEquals(5.0, buf.getDouble()); assertEquals(6.0, buf.getDouble());
+        assertEquals(1.0f, buf.getFloat()); assertEquals(2.0f, buf.getFloat()); assertEquals(3.0f, buf.getFloat());
+        assertEquals(4.0f, buf.getFloat()); assertEquals(5.0f, buf.getFloat()); assertEquals(6.0f, buf.getFloat());
         // Moon
-        assertEquals(7.0, buf.getDouble()); assertEquals(8.0, buf.getDouble()); assertEquals(9.0, buf.getDouble());
-        assertEquals(10.0, buf.getDouble()); assertEquals(11.0, buf.getDouble()); assertEquals(12.0, buf.getDouble());
+        assertEquals(7.0f, buf.getFloat()); assertEquals(8.0f, buf.getFloat()); assertEquals(9.0f, buf.getFloat());
+        assertEquals(10.0f, buf.getFloat()); assertEquals(11.0f, buf.getFloat()); assertEquals(12.0f, buf.getFloat());
 
         // Buffer should be exactly consumed
         assertEquals(0, buf.remaining(), "no trailing bytes");

--- a/docs/superpowers/specs/2026-05-18-dp853-emission-model-design.md
+++ b/docs/superpowers/specs/2026-05-18-dp853-emission-model-design.md
@@ -1,7 +1,7 @@
 # DP853 chunk-emission model
 
 **Date:** 2026-05-18
-**Status:** Design — awaiting decision
+**Status:** Design — decisions finalized, awaiting implementation
 **Tracker entry:** `todo.md` #69 (emission-mode design) — feeds #37 (per-chunk bandwidth)
 **Related:** `todo.md` #37, `2026-05-15-hermite-keyframe-interpolation-design.md`, [#13](https://github.com/byeonkho/spacesim/pull/13)
 **Companion data:** `ChunkSizeBenchmark.java` (run with `./mvnw test -Dtest=ChunkSizeBenchmark -Dchunk.benchmark=true`)
@@ -92,34 +92,83 @@ This is the deciding factor for Mode B vs Mode C:
 
 Reality drift (#39 in todo) and integrator residuals (#60) both display visible-quality diagnostics — they'll specifically expose any close-approach quality loss. Mode C is the right play if we want those features to read honest.
 
-## Recommendation: Mode C (replace + budget)
+## Decisions (finalized 2026-05-18)
 
-Concretely:
+### Two-tier wire-size ceiling
 
-1. **Wire-size target: 1 MB compressed per chunk** for the user-default preset. Headroom for 2 MB on the highest-fidelity preset; sub-300 KB on the most-aggressive thinning.
-2. **Snapshot budget per chunk: ~5000** at the default preset. With ~40 B compressed per snapshot·body × 10 bodies = ~400 B/snapshot compressed × 5000 = **2 MB compressed today**. Combined with float32 (option A from #37, ~2×): **~1 MB compressed**. Hits target.
-3. **For Euler/RK4: nothing changes.** Fixed-step, K stays as today. Already within budget.
-4. **For DP853: time-gap thinning** as the v1. Cheap, deterministic, preserves density. Revisit importance-weighted if visual quality regresses.
-5. **User-facing control:** "Playback quality" slider stays the same in the UI — backend translates the bucket to either K (for fixed-step) or snapshot budget N (for DP853). Slider semantics don't leak the integrator coupling.
-6. **`MAX_SNAPSHOTS_PER_CHUNK` becomes a real cap**, not a safety throw — set to N_max (the highest-fidelity preset), and the emission logic enforces it by construction. The exception goes away.
+DP853 is treated as an **opt-in heavier tier** — discoverable feature for users who want adaptive accuracy and are willing to pay the bandwidth. Default flows land on Euler/RK4.
 
-## Open questions
+| Tier | Wire-size ceiling (highest preset) | Snapshot ceiling (today) | With float32 |
+|---|---|---|---|
+| Default (Euler / RK4) | 2 MB compressed | ~5000 | ~1 MB |
+| DP853 (opt-in) | 6 MB compressed | ~15000 | ~3 MB |
 
-1. **Does Hipparchus expose accepted-substep timestamps + states cleanly through the StepHandler interface we already use, or does substep capture need re-plumbing?** Implementation detail, doesn't change the design — but affects effort estimate for Mode C.
-2. **Cross-chunk continuity under non-uniform thinning.** Chunk N+1 needs to dovetail with chunk N for Hermite reconstruction. The current `globalStepCount` cursor preserves this for fixed-step add-mode. Time-gap thinning needs the equivalent: each chunk starts time-gap accounting from the last kept substep of the previous chunk, not from the chunk boundary. Single integer in session state.
-3. **Default preset for DP853.** Today's "DP853 default = K=8" picks the per-integrator default in the SimSetupDrawer. Under Mode C, the equivalent is "DP853 default = N=5000 snapshots." Want to ship that as the default, or pick a smaller N to make the bandwidth win more obvious by default?
-4. **Backwards compat.** No existing sessions persist across deploys (in-memory only, idle-timeout sweeper), so we can break wire-format request params freely. Worth confirming there are no saved-URL flows that would break.
+Math: ~40 B compressed per snapshot·body × 10 bodies × N snapshots ≈ 400 B × N bytes compressed.
+
+### Preset map (5 buckets, matches existing Hermite UI)
+
+| Bucket | Euler / RK4 | DP853 |
+|---|---|---|
+| 1 (Lowest) | K=20 → ~500 snap (~0.2 MB) | N=3000 (~1.2 MB) |
+| 2 | K=10 → ~1000 (~0.4 MB) | N=5000 (~2 MB) |
+| 3 (Med) | K=5 → ~2000 (~0.8 MB) | N=7500 (~3 MB) |
+| 4 | K=2 → ~5000 (~2 MB) | N=10000 (~4 MB) |
+| 5 (Highest) | K=1 → ~10000 (~4 MB → 2 MB float32) | N=15000 (~6 MB → 3 MB float32) |
+
+### Landing defaults (per-integrator first-load preset)
+
+- **Euler** → bucket 4 (K=2, ~2 MB). Bumped from today's K=1 to fit the 2 MB ceiling pre-float32.
+- **RK4** → bucket 3 (K=5, ~0.8 MB). Slightly tighter than today's K=4 for headroom.
+- **DP853** → bucket 2 (N=5000, ~2 MB). Same ceiling as fixed-step defaults; reward for opting deeper into DP853 is moving up the slider.
+
+### Thinning algorithm
+
+**Time-gap.** Backend emits a snapshot when cumulative sim-time since last emission exceeds `chunk_duration / N`. Cheap, deterministic, density-preserving (regions where DP853 took many small substeps in a row naturally produce denser emissions because more small-step transitions cross any given time gap). Cross-chunk continuity: carry last-emit-time in session state so the next chunk's time-gap timer starts from that, not from the chunk boundary. Single `long` per session.
+
+Importance-weighted thinning held in reserve — revisit only if time-gap fails Hermite quality near close approaches in practice.
+
+### `MAX_SNAPSHOTS_PER_CHUNK` deleted
+
+With time-gap thinning the budget IS the cap, enforced by construction. Three things removed:
+1. `MAX_SNAPSHOTS_PER_CHUNK` constant in `SimulationLimits.java`
+2. `ChunkSnapshotBudgetExceededException` class
+3. The throw site in `Simulation.run()` + the test-only `maxSnapshotsPerChunk` overload in `SimulationFactory.createSimulation()`
+
+A "much larger safety net" would be unhit dead code. If time-gap thinning ever miscounts, we want the bug visible, not silently caught one threshold up.
+
+### Request API unified
+
+Replace the current `keyframesPerKept` request param with a single `fidelityBucket` enum (1–5) that the backend resolves per-integrator at `/initialize`. Cleaner contract; client doesn't need to know whether the integrator is fixed-step or adaptive. Backwards compat: no persisted sessions (idle-timeout sweeper at 15 min) — wire-param break is free.
+
+### Bundled with float32 in Phase 1
+
+Float32 quantization (#37 option A) lands in the same rollout window as Mode C. Bundling them means we ship one coherent "chunks are bounded now" change rather than two phases where day-one numbers don't quite hit target (Euler K=1 ships at 4 MB compressed today — over the 2 MB ceiling until float32 lands).
+
+---
+
+## Phased rollout
+
+Three phases, each on its own branch with verify-and-merge gate (per `branch-workflow.md`). Each phase is independently shippable and reversible.
+
+| Phase | Branch | Scope | Verify criterion |
+|---|---|---|---|
+| 1 | `chunk-float32` | Float32 positions+velocities in wire format. Serializer + parser + two-sided tests updated. Timestamp stays int64, µ stays float64. | ChunkSizeBenchmark shows ~half raw bytes; trail/scene visually unchanged; Keplerian elements display unchanged at the precision the body card renders. |
+| 2 | `dp853-time-gap` | Time-gap thinning in Simulation. Delete `MAX_SNAPSHOTS_PER_CHUNK` + exception + test-only overload. Backend internally accepts a `targetSnapshots` (N) param for DP853 (controller wires it from a temporary hardcoded default until Phase 3 surfaces the UI). Cross-chunk continuity via per-session last-emit-time. | ChunkSizeBenchmark with explicit N=5000 / N=10000 / N=15000 hits target snapshot counts ±5%; DP853 default no longer throws; no visible discontinuity in Hermite-interpolated trails across chunk boundaries during scrub. |
+| 3 | `fidelity-bucket-api` | Unify request API to `fidelityBucket` enum at `/initialize`. Frontend SimParams slider re-mapped per the preset table. Per-integrator landing defaults wired. Rate-limiter sizing comment updated for the new 6 MB DP853 ceiling. | Switching integrators auto-adjusts slider preset; DevTools chunk size per bucket × integrator matches the table within ±10%; landing defaults match the spec. |
+
+Phase 1 is the most mechanical (the wire-format pin tests give us a tight loop). Phase 2 is the most thinking-heavy (time-gap algorithm + continuity state + Hipparchus substep plumbing). Phase 3 is mostly UI + one DTO change.
+
+After Phase 3 lands, `todo.md` updates:
+- **#37** — close. Wire-size target hit via Float32 + Mode C; delta encoding deferred unless future need emerges.
+- **#69** — close. Emission model decided + shipped.
+- **Rate limiter sizing comment** in `RateLimitFilter.java` — update to reflect new 6 MB DP853 ceiling.
+
+## Open questions (implementation-time, don't block decision)
+
+1. **Hipparchus substep capture mechanism.** Does Mode C's time-gap logic plug into the existing StepHandler interface cleanly, or does substep capture need re-plumbing in `DormandPrince853Step`? Investigate at the start of Phase 2.
+2. **Bucket-resolution location.** Resolve `fidelityBucket → K` or `fidelityBucket → N` at the controller boundary (mirrors the current `keyframeIntervalSec → K` resolution) or push it into `SimulationFactory`? Decide during Phase 3.
 
 ## Out of scope (followups, not blockers)
 
-- **Float32 quantization (#37 option A).** Orthogonal — applies the same to all emission modes. Lands after Mode C as a clean 2× absolute cut.
-- **Delta encoding (#37 option B).** Bigger structural change; only worth doing if Mode C + float32 doesn't hit the target. Current math says they will.
-- **Re-sizing the rate limiter.** Today's nominal "4 MB chunk" sizing is wrong even for Euler K=1 (actually 4 MB compressed) and dramatically wrong for DP853 (16+ MB). Update the comment + sizing after Mode C lands and bytes are actually bounded.
-
-## Decision needed
-
-Before implementation:
-- (1) Confirm Mode C direction
-- (2) Confirm 1 MB compressed wire-size target + 5000-snapshot default budget
-- (3) Pick time-gap vs importance-weighted for v1 (recommend time-gap)
-- (4) Decide whether `MAX_SNAPSHOTS_PER_CHUNK` should remain a safety floor (set to e.g. 2× N_max) or be deleted entirely once the cap is enforced by construction
+- **Delta encoding (#37 option B).** Bigger structural change; only worth doing if Phase 1 + 2 don't hit the target. Current math says they will.
+- **Per-tier rate-limit accounting.** Today's rate limiter is bytes-per-IP-per-window agnostic of integrator. Once DP853 is heavier, a fairer model might be "chunks-per-IP-per-window" weighted by tier. Defer until usage data justifies it.

--- a/docs/superpowers/specs/2026-05-18-dp853-emission-model-design.md
+++ b/docs/superpowers/specs/2026-05-18-dp853-emission-model-design.md
@@ -1,0 +1,125 @@
+# DP853 chunk-emission model
+
+**Date:** 2026-05-18
+**Status:** Design — awaiting decision
+**Tracker entry:** `todo.md` #69 (emission-mode design) — feeds #37 (per-chunk bandwidth)
+**Related:** `todo.md` #37, `2026-05-15-hermite-keyframe-interpolation-design.md`, [#13](https://github.com/byeonkho/spacesim/pull/13)
+**Companion data:** `ChunkSizeBenchmark.java` (run with `./mvnw test -Dtest=ChunkSizeBenchmark -Dchunk.benchmark=true`)
+
+## Summary
+
+DP853 default settings emit ~41000 snapshots per chunk for a 10-body solar system over 10000 hours — **2× past the current `MAX_SNAPSHOTS_PER_CHUNK = 20000` budget**, throwing `ChunkSnapshotBudgetExceededException` at user-default fidelity. Beyond the budget exception, the resulting ~16 MB compressed chunks are ~16× the bandwidth target in #37.
+
+The root cause isn't the budget number — it's the **emission model**. Today DP853 ships every internally-accepted adaptive substep AND its share of the external-step grid keyframes (thinned by K). Substeps alone are ~40000 per chunk and entirely dominate; K barely matters for DP853 bytes (range 16–19 MB across K=1..K=8).
+
+This doc walks through what's happening (ELI5), the three candidate emission models, and recommends **replace-mode with a snapshot budget**.
+
+## ELI5: what the integrator actually does
+
+Think of the simulation as a hiker walking a long trail. The trail is the timeline; "snapshots" are photos along the way that get shipped back to the frontend so it can draw the orbit.
+
+**Fixed-step integrators (Euler, RK4):** disciplined hiker. *"I'll take a photo every 100 meters, no exceptions."* Predictable photo count: trail length ÷ 100m. The user's "Playback quality" setting (K) says "send back every Kth photo" — a clean thinning.
+
+**Adaptive integrator (DP853):** smart hiker who slows down on tricky terrain. *"I default to walking 100m at a time, but if I hit cliffs or a river, I shrink my stride down to 1m until I'm past it — I have to, or I'll fall."* On a flat path she takes 100 photos in 10 km. Going over a mountain pass she might take 500 photos in the same 10 km. The photo count depends on the terrain, not just the trail length.
+
+Today we ship **both sets of photos**: every shrunk-stride photo DP853 took for accuracy reasons, PLUS one photo every 100m × K from the imagined "external" grid. That's the "add-mode" in #69.
+
+The result for our solar-system benchmark: ~40000 adaptive substep photos + ~1250 external-grid photos at K=8 = **~41250 photos per chunk**. Eight times the snapshots Euler ships at K=1, and the user thinks they picked a "medium fidelity" setting.
+
+## What the wire actually looks like (data)
+
+From `ChunkSizeBenchmark.java`, 10 bodies, hours unit, 10000-hour chunk:
+
+| Scenario             | Snapshots | Raw KB | Zstd KB | Ratio | B/snap·body |
+|----------------------|-----------|--------|---------|-------|-------------|
+| Euler K=1            | 10001     | 4766   | 4096    | 1.16× | 41.94       |
+| RK4 K=4              | 2501      | 1192   | 1027    | 1.16× | 42.05       |
+| DP853 K=8 (default!) | 41251     | 19659  | 16396   | 1.20× | 40.70       |
+| DP853 K=4            | 42501     | 20254  | 16751   | 1.21× | 40.36       |
+| DP853 K=1 (stress)   | 50001     | 23828  | 19160   | 1.24× | 39.24       |
+
+Two findings worth flagging:
+
+1. **Zstd buys almost nothing on this payload (~1.2×).** Float64 mantissas look like noise — there's no structural redundancy to compress. The `SimulationLimits` docstring's implicit ~3–4× ratio assumption is wrong. Implication: format-level redundancy (delta encoding, #37 option B) would actually compress; raw quantization (float32, #37 option A) is a clean ~2× absolute win but doesn't change the order of magnitude.
+
+2. **K barely affects DP853 bytes.** Substeps dominate (~40000) across all K, because K only thins the external-grid layer that's added on top. The user's fidelity slider has essentially no bandwidth effect on DP853 today.
+
+## The three candidate emission models
+
+### Mode A — Add (current)
+
+```
+emitted = adaptive_substeps_all + external_step_keyframes[every Kth]
+```
+
+- **Pro:** K's user-facing meaning is uniform across integrators ("send every Kth regular step"). Substep capture preserves the integrator's adaptive density signal — Hermite interpolation has the densest sampling exactly where DP853 needed accuracy.
+- **Con:** Bytes per chunk are integrator-controlled, not user-controlled. K is a near-no-op for DP853. 16+ MB chunks at the default. Throws the budget exception today.
+
+### Mode B — Replace (substeps replace external grid for DP853)
+
+```
+DP853:       emitted = adaptive_substeps[every Kth]
+Euler / RK4: emitted = external_step_keyframes[every Kth]   (unchanged)
+```
+
+- **Pro:** Bytes scale with K for DP853 too. K=1 ≈ 40000 snapshots (~16 MB), K=8 ≈ 5000 (~2 MB), K=32 ≈ 1250 (~0.5 MB). The user's fidelity slider becomes meaningful for DP853 bandwidth.
+- **Con:** K's meaning splits across integrators ("every Kth external step" vs "every Kth adaptive step"). Worse: **uniform-K thinning destroys the adaptive density signal**. If DP853 shrunk its stride 50× during a close approach to integrate accurately, we'd thin those tight substeps the same way as the rest — losing exactly the resolution DP853 paid CPU to produce. Hermite quality drops noticeably near close approaches at high K.
+
+### Mode C — Replace + snapshot budget (recommended)
+
+```
+DP853:       emitted = adaptive_substeps thinned non-uniformly to ≤ N
+Euler / RK4: unchanged
+```
+
+The user picks a "Playback quality" preset that maps to a **target snapshot count** N (say 1k / 2.5k / 5k / 10k per chunk). The backend keeps every Nth substep — except where DP853 took rapid bursts of tiny steps, where it keeps more. Two viable thinning strategies:
+
+- **Time-gap thinning:** capture a substep when cumulative time since last capture exceeds `chunk_duration / N`. Naturally produces denser samples in regions where DP853 took many small steps in a row (because more of those small steps cross any given time threshold). Cheap, deterministic.
+- **Importance-weighted thinning:** rank substeps by `1 / step_size_taken` (or local error estimate, which DP853 already computes), keep the top N. More accurate density-preservation but pricier to compute and harder to reason about cross-chunk.
+
+Either way, the user contract becomes "what payload size do you want," not "what's K." K stays as the user-facing fidelity slider for Euler/RK4 (where it still means "every Kth regular step"). Bandwidth bound becomes a backend-enforced cap, not an emergent property.
+
+- **Pro:** Bounded payload regardless of integrator or scenario chaoticness. Preserves adaptive density (more samples where DP853 cared more). One snapshot-budget number is a defensible thing to size against the wire-size target. Removes the integrator-coupling from `MAX_SNAPSHOTS_PER_CHUNK` — the budget becomes the contract, not a safety throw.
+- **Con:** Most implementation work — non-uniform thinning logic + new request param + UI changes. Per-chunk snapshot count is no longer a function of (integrator, K) alone — slightly less predictable for tests.
+
+## Hermite reconstruction — why this constraint matters
+
+The frontend uses cubic Hermite interpolation between samples (per `2026-05-15-hermite-keyframe-interpolation-design.md`). Hermite quality is **density-sensitive**: cubic between two samples is exact only if motion is locally cubic. Near a close approach, position can change non-cubically over 30 minutes; if we have samples only every 8 hours there, the interpolated trail will visibly cut the corner.
+
+This is the deciding factor for Mode B vs Mode C:
+- Mode B with uniform-K thinning: thins close-approach substeps the same as cruise substeps. Trail quality degrades visibly near close approaches at high K.
+- Mode C (time-gap or importance-weighted): preserves the density signal. Trail quality degrades smoothly with N, with no per-event cliffs.
+
+Reality drift (#39 in todo) and integrator residuals (#60) both display visible-quality diagnostics — they'll specifically expose any close-approach quality loss. Mode C is the right play if we want those features to read honest.
+
+## Recommendation: Mode C (replace + budget)
+
+Concretely:
+
+1. **Wire-size target: 1 MB compressed per chunk** for the user-default preset. Headroom for 2 MB on the highest-fidelity preset; sub-300 KB on the most-aggressive thinning.
+2. **Snapshot budget per chunk: ~5000** at the default preset. With ~40 B compressed per snapshot·body × 10 bodies = ~400 B/snapshot compressed × 5000 = **2 MB compressed today**. Combined with float32 (option A from #37, ~2×): **~1 MB compressed**. Hits target.
+3. **For Euler/RK4: nothing changes.** Fixed-step, K stays as today. Already within budget.
+4. **For DP853: time-gap thinning** as the v1. Cheap, deterministic, preserves density. Revisit importance-weighted if visual quality regresses.
+5. **User-facing control:** "Playback quality" slider stays the same in the UI — backend translates the bucket to either K (for fixed-step) or snapshot budget N (for DP853). Slider semantics don't leak the integrator coupling.
+6. **`MAX_SNAPSHOTS_PER_CHUNK` becomes a real cap**, not a safety throw — set to N_max (the highest-fidelity preset), and the emission logic enforces it by construction. The exception goes away.
+
+## Open questions
+
+1. **Does Hipparchus expose accepted-substep timestamps + states cleanly through the StepHandler interface we already use, or does substep capture need re-plumbing?** Implementation detail, doesn't change the design — but affects effort estimate for Mode C.
+2. **Cross-chunk continuity under non-uniform thinning.** Chunk N+1 needs to dovetail with chunk N for Hermite reconstruction. The current `globalStepCount` cursor preserves this for fixed-step add-mode. Time-gap thinning needs the equivalent: each chunk starts time-gap accounting from the last kept substep of the previous chunk, not from the chunk boundary. Single integer in session state.
+3. **Default preset for DP853.** Today's "DP853 default = K=8" picks the per-integrator default in the SimSetupDrawer. Under Mode C, the equivalent is "DP853 default = N=5000 snapshots." Want to ship that as the default, or pick a smaller N to make the bandwidth win more obvious by default?
+4. **Backwards compat.** No existing sessions persist across deploys (in-memory only, idle-timeout sweeper), so we can break wire-format request params freely. Worth confirming there are no saved-URL flows that would break.
+
+## Out of scope (followups, not blockers)
+
+- **Float32 quantization (#37 option A).** Orthogonal — applies the same to all emission modes. Lands after Mode C as a clean 2× absolute cut.
+- **Delta encoding (#37 option B).** Bigger structural change; only worth doing if Mode C + float32 doesn't hit the target. Current math says they will.
+- **Re-sizing the rate limiter.** Today's nominal "4 MB chunk" sizing is wrong even for Euler K=1 (actually 4 MB compressed) and dramatically wrong for DP853 (16+ MB). Update the comment + sizing after Mode C lands and bytes are actually bounded.
+
+## Decision needed
+
+Before implementation:
+- (1) Confirm Mode C direction
+- (2) Confirm 1 MB compressed wire-size target + 5000-snapshot default budget
+- (3) Pick time-gap vs importance-weighted for v1 (recommend time-gap)
+- (4) Decide whether `MAX_SNAPSHOTS_PER_CHUNK` should remain a safety floor (set to e.g. 2× N_max) or be deleted entirely once the cap is enforced by construction

--- a/frontend/src/app/store/middleware/parseBinaryChunk.test.ts
+++ b/frontend/src/app/store/middleware/parseBinaryChunk.test.ts
@@ -20,7 +20,8 @@ function buildChunkBytes(
     // Each body: 2 (nameLen) + name bytes + 8 (µ).
     encodedNames.reduce((sum, b) => sum + 2 + b.length + 8, 0) +
     4;
-  const perTimestep = 8 + bodies.length * 6 * 8;
+  // Positions + velocities are float32 (4 bytes each); timestamp stays int64, µ stays float64.
+  const perTimestep = 8 + bodies.length * 6 * 4;
   const total = headerSize + timesteps.length * perTimestep;
 
   const buf = new ArrayBuffer(total);
@@ -46,12 +47,12 @@ function buildChunkBytes(
     view.setBigInt64(offset, BigInt(t.millis), true);
     offset += 8;
     for (const body of t.bodies) {
-      view.setFloat64(offset, body.pos[0], true); offset += 8;
-      view.setFloat64(offset, body.pos[1], true); offset += 8;
-      view.setFloat64(offset, body.pos[2], true); offset += 8;
-      view.setFloat64(offset, body.vel[0], true); offset += 8;
-      view.setFloat64(offset, body.vel[1], true); offset += 8;
-      view.setFloat64(offset, body.vel[2], true); offset += 8;
+      view.setFloat32(offset, body.pos[0], true); offset += 4;
+      view.setFloat32(offset, body.pos[1], true); offset += 4;
+      view.setFloat32(offset, body.pos[2], true); offset += 4;
+      view.setFloat32(offset, body.vel[0], true); offset += 4;
+      view.setFloat32(offset, body.vel[1], true); offset += 4;
+      view.setFloat32(offset, body.vel[2], true); offset += 4;
     }
   }
   return out;

--- a/frontend/src/app/store/middleware/parseBinaryChunk.ts
+++ b/frontend/src/app/store/middleware/parseBinaryChunk.ts
@@ -9,10 +9,17 @@
 //   per timestep:
 //     int64    timestamp (millis since UNIX epoch, UTC)
 //     per body (header order):
-//       float64 × 6   (px, py, pz, vx, vy, vz)
+//       float32 × 6   (px, py, pz, vx, vy, vz)
+//
+// Positions + velocities use float32 — ~7-decimal-digit precision is fine
+// for visualisation and halves the per-timestep wire size. Decoded into the
+// existing Float64Array buffer via implicit widening; downstream consumers
+// (Sphere, Trail, etc.) see no shape change.
 //
 // `mu` is the standard gravitational parameter (G·M, m³/s²) for each body —
-// constant per session, sent once with names. Used client-side to derive
+// constant per session, sent once with names. Stays float64 because µ
+// appears once per session per body (not per timestep) and the Keplerian
+// derivation is sensitive to µ precision. Used client-side to derive
 // Keplerian orbital elements from (r, v) state vectors. µ=0 means "unknown"
 // (backend missing-entry fallback) and downstream code skips Keplerian
 // rendering for that body rather than producing NaN cascades.
@@ -67,12 +74,12 @@ export function parseBinaryChunk(bytes: Uint8Array): ParsedChunk {
 
     const snapshot: CelestialBody[] = new Array(bodyCount);
     for (let b = 0; b < bodyCount; b++) {
-      const px = view.getFloat64(offset, true); offset += 8;
-      const py = view.getFloat64(offset, true); offset += 8;
-      const pz = view.getFloat64(offset, true); offset += 8;
-      const vx = view.getFloat64(offset, true); offset += 8;
-      const vy = view.getFloat64(offset, true); offset += 8;
-      const vz = view.getFloat64(offset, true); offset += 8;
+      const px = view.getFloat32(offset, true); offset += 4;
+      const py = view.getFloat32(offset, true); offset += 4;
+      const pz = view.getFloat32(offset, true); offset += 4;
+      const vx = view.getFloat32(offset, true); offset += 4;
+      const vy = view.getFloat32(offset, true); offset += 4;
+      const vz = view.getFloat32(offset, true); offset += 4;
       snapshot[b] = {
         name: names[b],
         position: { x: px, y: py, z: pz },
@@ -137,12 +144,13 @@ export function parseBinaryChunkToTypedArrays(
     const tBase = t * bodyCount * 6;
     for (let b = 0; b < bodyCount; b++) {
       const slotBase = tBase + b * 6;
-      positions[slotBase + 0] = view.getFloat64(offset, true); offset += 8;
-      positions[slotBase + 1] = view.getFloat64(offset, true); offset += 8;
-      positions[slotBase + 2] = view.getFloat64(offset, true); offset += 8;
-      positions[slotBase + 3] = view.getFloat64(offset, true); offset += 8;
-      positions[slotBase + 4] = view.getFloat64(offset, true); offset += 8;
-      positions[slotBase + 5] = view.getFloat64(offset, true); offset += 8;
+      // Float32 reads widen to float64 on assignment into the Float64Array slot.
+      positions[slotBase + 0] = view.getFloat32(offset, true); offset += 4;
+      positions[slotBase + 1] = view.getFloat32(offset, true); offset += 4;
+      positions[slotBase + 2] = view.getFloat32(offset, true); offset += 4;
+      positions[slotBase + 3] = view.getFloat32(offset, true); offset += 4;
+      positions[slotBase + 4] = view.getFloat32(offset, true); offset += 4;
+      positions[slotBase + 5] = view.getFloat32(offset, true); offset += 4;
     }
   }
 


### PR DESCRIPTION
## Summary

First chunk in the chunk-optimisation work (todos #37 + #69). Three logical pieces:

- **Measurement infrastructure** — `ChunkSizeBenchmark` walks the realistic integrator × K matrix and prints raw + compressed bytes per chunk. Gated behind `-Dchunk.benchmark=true`.
- **Design doc** — [2026-05-18-dp853-emission-model-design.md](https://github.com/byeonkho/spacesim/blob/chunk-float32/docs/superpowers/specs/2026-05-18-dp853-emission-model-design.md). Walks ELI5 through DP853 substep emission, three candidate models (add / replace / replace+budget), and the finalized decisions: Mode C (replace + time-gap thinning), two-tier wire-size ceiling (2 MB default, 6 MB DP853 opt-in), unified `fidelityBucket` API, `MAX_SNAPSHOTS_PER_CHUNK` deletion. Three-phase rollout.
- **Phase 1** — float32 positions+velocities in the wire format. Timestamp stays int64, µ stays float64. Two-sided wire-format tests updated; small-integer fixtures roundtrip exactly through float32 so expected values are unchanged.

## Key finding from measurement

Zstd is barely helping the original payload (~1.2× ratio) because float64 mantissas look like noise. This reshaped the plan — emission-model redesign (#69) became the dominant lever, with float32 as a clean orthogonal cut. Full numbers + analysis in the design doc.

## Phase 1 verify

| Scenario | Before zstd | After zstd | Delta |
|---|---|---|---|
| Euler K=1 | 4096 KB | 2005 KB | -51% |
| RK4 K=4 | 1027 KB | 504 KB | -51% |
| DP853 K=8 (default) | 16396 KB | 7474 KB | -54% |
| DP853 K=1 (stress) | 19160 KB | 8434 KB | -56% |

Compressed reduction slightly beats 50% because float32 mantissas compress better than float64 ones.

## Test plan

- [x] Backend: `./mvnw test` — 50/50 green
- [x] Frontend: `npm test` — 145/145 green
- [x] Frontend: `npm run build && npm run lint` — clean
- [x] `tsc --noEmit` — pre-existing debt only (confirmed identical on master)
- [x] ChunkSizeBenchmark re-run confirms ~half raw bytes
- [x] Browser smoke check — byeon verified locally (trail/scene + Keplerian display unchanged)

## What's next

Phase 2 (`dp853-time-gap` branch): time-gap thinning in `Simulation.java`, delete `MAX_SNAPSHOTS_PER_CHUNK` + exception, internal `targetSnapshots` request param wired (UI surfaces in Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)