### PR TITLE
feat: live body render in the info panel

### DIFF
--- a/frontend/src/app/components/chrome/BodyCard.tsx
+++ b/frontend/src/app/components/chrome/BodyCard.tsx
@@ -32,7 +32,7 @@ import {
 import { selectOverlayEnabled } from "@/app/store/slices/GroundTruthSlice";
 import { driftMetrics } from "@/app/utils/driftMetrics";
 import { DRIFT_READOUT_COPY } from "@/app/constants/driftTooltipCopy";
-import { BodySphere } from "@/app/components/chrome/BodySphere";
+import { BodyPortrait } from "@/app/components/chrome/BodyPortrait";
 import { InfoTooltip } from "@/app/components/chrome/InfoTooltip";
 
 // Right-column body card. Identity (name, orbiting body) comes from
@@ -361,7 +361,7 @@ export function BodyCard() {
       style={{ borderRadius: 14 }}
     >
       <div className="mb-2.5 flex items-center gap-2.5">
-        {bodyKey && <BodySphere body={bodyKey} size={18} glow />}
+        {bodyKey && <BodyPortrait body={bodyKey} size={44} />}
         <div className="text-hi text-[17px] font-semibold tracking-[-0.015em]">
           {display}
         </div>

--- a/frontend/src/app/components/chrome/BodyPortrait.tsx
+++ b/frontend/src/app/components/chrome/BodyPortrait.tsx
@@ -2,8 +2,11 @@
 
 import { Canvas, useFrame, useLoader } from "@react-three/fiber";
 import { Suspense, useRef } from "react";
+import { useStore } from "react-redux";
 import * as THREE from "three";
 import { type BodyKey, BODY_COLOR, BODY_TEXTURE } from "@/app/constants/BodyVisuals";
+import { readBodyPositionInto } from "@/app/store/chunkBuffer";
+import type { RootState } from "@/app/store/Store";
 
 // Small live render of the selected body for the info-panel header. A textured
 // sphere lit from the Sun's real direction (so its real day/night phase reads),
@@ -58,6 +61,7 @@ export function BodyPortrait({ body, size = 44 }: BodyPortraitProps) {
 function PortraitSphere({ body }: { body: BodyKey }) {
   const meshRef = useRef<THREE.Mesh>(null!);
   const lightRef = useRef<THREE.DirectionalLight>(null!);
+  const store = useStore<RootState>();
 
   const texture = useLoader(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -65,11 +69,72 @@ function PortraitSphere({ body }: { body: BodyKey }) {
     BODY_TEXTURE[body].src,
   );
 
+  // Scratch vectors — never reallocated (hot path).
+  const bodyScratch = useRef(new THREE.Vector3());
+  const sunScratch = useRef(new THREE.Vector3());
+
+  // Cached buffer slots. Active-body component: the rendered body is dynamic, so
+  // invalidate on BOTH buffer identity AND body change (the DriftOverlay
+  // precedent, not the fixed-body Sphere/Trail one).
+  const bodyIdxRef = useRef(-1);
+  const sunIdxRef = useRef(-1);
+  const resolvedBufferRef = useRef<object | null>(null);
+  const resolvedBodyRef = useRef<BodyKey | null>(null);
+
   useFrame((_, delta) => {
     if (meshRef.current) meshRef.current.rotation.y += SPIN_RATE * delta;
-    if (lightRef.current) {
-      lightRef.current.position.copy(DEFAULT_LIGHT_DIR).multiplyScalar(LIGHT_DIST);
+    const light = lightRef.current;
+    if (!light) return;
+
+    const state = store.getState();
+    const buffer = state.simulation.chunkBuffer;
+    const idx = state.simulation.timeState.currentTimeStepIndex;
+
+    // No positions yet — keep a sensible default so the body isn't born dark.
+    if (!buffer || idx >= buffer.totalTimesteps) {
+      light.position.copy(DEFAULT_LIGHT_DIR).multiplyScalar(LIGHT_DIST);
+      return;
     }
+
+    if (resolvedBufferRef.current !== buffer || resolvedBodyRef.current !== body) {
+      bodyIdxRef.current = -1;
+      sunIdxRef.current = -1;
+      resolvedBufferRef.current = buffer;
+      resolvedBodyRef.current = body;
+    }
+    if (bodyIdxRef.current === -1) {
+      for (const [bn, i] of buffer.bodyNameToIndex.entries()) {
+        const up = bn.toUpperCase();
+        if (up === body) bodyIdxRef.current = i;
+        if (up === "SUN") sunIdxRef.current = i;
+      }
+    }
+
+    const bodyIdx = bodyIdxRef.current;
+    const sunIdx = sunIdxRef.current;
+    // Body or Sun not in this sim — fall back to the default direction.
+    if (bodyIdx < 0 || sunIdx < 0) {
+      light.position.copy(DEFAULT_LIGHT_DIR).multiplyScalar(LIGHT_DIST);
+      return;
+    }
+
+    readBodyPositionInto(bodyScratch.current, buffer, idx, bodyIdx);
+    readBodyPositionInto(sunScratch.current, buffer, idx, sunIdx);
+
+    // Raw ICRF direction body -> Sun. Translation-invariant, so no frame pivot
+    // or scale pipeline needed (the geo/helio pivot is a common translation that
+    // cancels in the difference). Map ICRF -> portrait space with the scene's
+    // Y/Z swap (ICRF z -> portrait up) so the orbit's sun direction sweeps the
+    // portrait's horizontal plane and the phase varies fully over the orbit.
+    const dx = sunScratch.current.x - bodyScratch.current.x;
+    const dy = sunScratch.current.y - bodyScratch.current.y;
+    const dz = sunScratch.current.z - bodyScratch.current.z;
+    const len = Math.hypot(dx, dy, dz) || 1;
+    light.position.set(
+      (dx / len) * LIGHT_DIST,
+      (dz / len) * LIGHT_DIST,
+      (dy / len) * LIGHT_DIST,
+    );
   });
 
   return (

--- a/frontend/src/app/components/chrome/BodyPortrait.tsx
+++ b/frontend/src/app/components/chrome/BodyPortrait.tsx
@@ -11,7 +11,7 @@ import type { RootState } from "@/app/store/Store";
 // Small live render of the selected body for the info-panel header. A textured
 // sphere lit from the Sun's real direction (so its real day/night phase reads),
 // gently spinning, fixed camera. Self-contained: its own tiny WebGL canvas,
-// decoupled from the main scene. Design decisions: see the live-body-render spec.
+// decoupled from the main scene.
 
 const CAM_DIST = 4.2;
 const SPHERE_RADIUS = 1;

--- a/frontend/src/app/components/chrome/BodyPortrait.tsx
+++ b/frontend/src/app/components/chrome/BodyPortrait.tsx
@@ -62,6 +62,7 @@ function PortraitSphere({ body }: { body: BodyKey }) {
   const meshRef = useRef<THREE.Mesh>(null!);
   const lightRef = useRef<THREE.DirectionalLight>(null!);
   const store = useStore<RootState>();
+  const isSun = body === "SUN";
 
   const texture = useLoader(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -83,6 +84,7 @@ function PortraitSphere({ body }: { body: BodyKey }) {
 
   useFrame((_, delta) => {
     if (meshRef.current) meshRef.current.rotation.y += SPIN_RATE * delta;
+    if (isSun) return; // emissive — no phase, and self-difference is a zero vector
     const light = lightRef.current;
     if (!light) return;
 
@@ -143,7 +145,11 @@ function PortraitSphere({ body }: { body: BodyKey }) {
       <directionalLight ref={lightRef} intensity={DIR_LIGHT_INTENSITY} />
       <mesh ref={meshRef}>
         <sphereGeometry args={[SPHERE_RADIUS, 48, 48]} />
-        <meshStandardMaterial map={texture} />
+        {isSun ? (
+          <meshBasicMaterial map={texture} />
+        ) : (
+          <meshStandardMaterial map={texture} />
+        )}
       </mesh>
     </>
   );

--- a/frontend/src/app/components/chrome/BodyPortrait.tsx
+++ b/frontend/src/app/components/chrome/BodyPortrait.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Canvas, useFrame, useLoader } from "@react-three/fiber";
+import { Suspense, useRef } from "react";
+import * as THREE from "three";
+import { type BodyKey, BODY_COLOR, BODY_TEXTURE } from "@/app/constants/BodyVisuals";
+
+// Small live render of the selected body for the info-panel header. A textured
+// sphere lit from the Sun's real direction (so its real day/night phase reads),
+// gently spinning, fixed camera. Self-contained: its own tiny WebGL canvas,
+// decoupled from the main scene. Design decisions: see the live-body-render spec.
+
+const CAM_DIST = 4.2;
+const SPHERE_RADIUS = 1;
+const LIGHT_DIST = 6;
+const DIR_LIGHT_INTENSITY = 3;
+const AMBIENT_INTENSITY = 0.12;
+const SPIN_RATE = 0.35; // rad/s, gentle decorative spin (tunable)
+
+// Light direction used before the first buffer read resolves, and as the
+// fallback when the Sun isn't in the selected set: up-and-to-the-left, so the
+// body is never born fully dark. Module scope so the Vector3 is allocated once.
+const DEFAULT_LIGHT_DIR = new THREE.Vector3(-0.6, 0.4, 0.7).normalize();
+
+interface BodyPortraitProps {
+  body: BodyKey;
+  size?: number;
+}
+
+export function BodyPortrait({ body, size = 44 }: BodyPortraitProps) {
+  return (
+    <div style={{ position: "relative", width: size, height: size, flexShrink: 0 }}>
+      {/* Subtle body-tinted glow ring, preserving the header's prior look. */}
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          inset: 0,
+          borderRadius: "50%",
+          boxShadow: `0 0 ${Math.round(size * 0.4)}px ${BODY_COLOR[body]}55`,
+        }}
+      />
+      <Canvas
+        flat
+        gl={{ alpha: true }}
+        dpr={[1, 2]}
+        camera={{ position: [0, 0, CAM_DIST], fov: 30, near: 0.1, far: 100 }}
+        style={{ width: size, height: size, position: "relative", pointerEvents: "none" }}
+      >
+        <Suspense fallback={null}>
+          <PortraitSphere body={body} />
+        </Suspense>
+      </Canvas>
+    </div>
+  );
+}
+
+function PortraitSphere({ body }: { body: BodyKey }) {
+  const meshRef = useRef<THREE.Mesh>(null!);
+  const lightRef = useRef<THREE.DirectionalLight>(null!);
+
+  const texture = useLoader(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    THREE.TextureLoader as any,
+    BODY_TEXTURE[body].src,
+  );
+
+  useFrame((_, delta) => {
+    if (meshRef.current) meshRef.current.rotation.y += SPIN_RATE * delta;
+    if (lightRef.current) {
+      lightRef.current.position.copy(DEFAULT_LIGHT_DIR).multiplyScalar(LIGHT_DIST);
+    }
+  });
+
+  return (
+    <>
+      <ambientLight intensity={AMBIENT_INTENSITY} />
+      <directionalLight ref={lightRef} intensity={DIR_LIGHT_INTENSITY} />
+      <mesh ref={meshRef}>
+        <sphereGeometry args={[SPHERE_RADIUS, 48, 48]} />
+        <meshStandardMaterial map={texture} />
+      </mesh>
+    </>
+  );
+}

--- a/frontend/src/app/components/chrome/RightColumn.tsx
+++ b/frontend/src/app/components/chrome/RightColumn.tsx
@@ -9,7 +9,7 @@ import { EventLogCard } from "@/app/components/chrome/EventLogCard";
 export function RightColumn() {
   return (
     <div
-      className="pointer-events-auto absolute top-[128px] right-6 flex w-[316px] flex-col gap-3"
+      className="pointer-events-auto absolute top-[148px] right-6 flex w-[316px] flex-col gap-3"
       style={{ bottom: 114 }}
     >
       <BodyCard />


### PR DESCRIPTION
## Summary
- Replaces the flat gradient dot in the info-panel body card header with a small live WebGL render (`BodyPortrait`): a textured sphere, gently spinning, lit from the Sun's real direction so the body's actual day/night phase reads. Self-contained mini-canvas, decoupled from the main scene.
- The Sun renders emissive (no phase). Bodies/Sun absent from the sim, or before the first chunk arrives, fall back to a default light direction.
- Hot-path safe: zero per-frame allocations, imperative `store.getState()` reads, active-body buffer-index invalidation (buffer + body).
- Also drops the right column ~20px (`top-128` → `top-148`) to clear the centered top selector — a pre-existing crowding issue surfaced while reviewing the larger header.

## Test plan
- [x] `npm run build`, `npm run lint`, `npx tsc --noEmit` (no new errors in touched files), `npm test` (253 passing)
- [x] Manual: selected Earth / Mars / Jupiter / Moon / asteroid / Sun in both Realistic and Stylized presets — textured, correct phase, phase varies over the orbit, Sun full-bright, no stale-index cross-lighting between bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)