### PR TITLE
fix(backend): make session teardown atomic

### DIFF
--- a/backend/src/main/java/personal/spacesim/services/SimulationSessionService.java
+++ b/backend/src/main/java/personal/spacesim/services/SimulationSessionService.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.LongSupplier;
 
 @Component
 public class SimulationSessionService {
@@ -49,6 +50,7 @@ public class SimulationSessionService {
     private final SimulationFactory simulationFactory;
     private final BinaryResponseSerializer binaryResponseSerializer;
     private final ZstdCompressor zstdCompressor;
+    private final LongSupplier currentTimeMillis;
 
     // Bounded executor for precompute work. Threads are daemon so they don't
     // prevent JVM shutdown if a request is in flight at exit.
@@ -66,9 +68,20 @@ public class SimulationSessionService {
             BinaryResponseSerializer binaryResponseSerializer,
             ZstdCompressor zstdCompressor
     ) {
+        this(simulationFactory, binaryResponseSerializer, zstdCompressor,
+                System::currentTimeMillis);
+    }
+
+    SimulationSessionService(
+            SimulationFactory simulationFactory,
+            BinaryResponseSerializer binaryResponseSerializer,
+            ZstdCompressor zstdCompressor,
+            LongSupplier currentTimeMillis
+    ) {
         this.simulationFactory = simulationFactory;
         this.binaryResponseSerializer = binaryResponseSerializer;
         this.zstdCompressor = zstdCompressor;
+        this.currentTimeMillis = currentTimeMillis;
         this.sessions = new ConcurrentHashMap<>();
     }
 
@@ -101,7 +114,7 @@ public class SimulationSessionService {
                 targetSnapshotsPerChunk
         );
         sessions.put(sessionID, new SimulationSessionState(
-                simulation, System.currentTimeMillis()));
+                simulation, currentTimeMillis.getAsLong()));
         logger.info("sessionID: {}", sessionID);
         return sessionID;
     }
@@ -148,7 +161,7 @@ public class SimulationSessionService {
      */
     public byte[] getNextChunkBytes(String sessionID, int expectedChunkIndex) {
         SimulationSessionState state = sessions.get(sessionID);
-        if (state == null || !state.touchIfOpen(System.currentTimeMillis())) {
+        if (state == null || !state.touchIfOpen(currentTimeMillis.getAsLong())) {
             throw sessionNotFound(sessionID);
         }
 
@@ -267,7 +280,7 @@ public class SimulationSessionService {
      */
     @Scheduled(fixedRate = 60_000)
     public void evictIdleSimulations() {
-        long now = System.currentTimeMillis();
+        long now = currentTimeMillis.getAsLong();
         for (Map.Entry<String, SimulationSessionState> entry : sessions.entrySet()) {
             String sessionID = entry.getKey();
             SimulationSessionState state = entry.getValue();

--- a/backend/src/main/java/personal/spacesim/services/SimulationSessionService.java
+++ b/backend/src/main/java/personal/spacesim/services/SimulationSessionService.java
@@ -16,7 +16,6 @@ import personal.spacesim.utils.compressor.ZstdCompressor;
 import personal.spacesim.utils.serializers.BinaryResponseSerializer;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,25 +45,10 @@ public class SimulationSessionService {
     // sessions after IDLE_TIMEOUT_MS.
     private static final int MAX_CONCURRENT_SESSIONS = 50;
 
-    private final ConcurrentHashMap<String, Simulation> simulationMap;
-    private final ConcurrentHashMap<String, Long> lastAccessedAt;
+    private final ConcurrentHashMap<String, SimulationSessionState> sessions;
     private final SimulationFactory simulationFactory;
     private final BinaryResponseSerializer binaryResponseSerializer;
     private final ZstdCompressor zstdCompressor;
-
-    // Per-session next-chunk precompute. The future may be in-flight or done.
-    // Missing entry = no precompute kicked off yet (first request, or after eviction).
-    private final ConcurrentHashMap<String, CompletableFuture<byte[]>> nextChunkCache;
-
-    // Per-session chunk-protocol state. servedChunkIndex is the index of the last
-    // chunk produced for the session (-1 = none yet). lastChunkBytes holds that
-    // chunk's payload so a client retry for the same index re-serves it instead of
-    // advancing the cursor (idempotent retry, fixes the dropped-chunk-on-blip bug).
-    // sessionLocks serializes the decide-and-produce critical section per session,
-    // so Simulation.run() is never executed concurrently for one session.
-    private final ConcurrentHashMap<String, Integer> servedChunkIndex = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, byte[]> lastChunkBytes = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, ReentrantLock> sessionLocks = new ConcurrentHashMap<>();
 
     // Bounded executor for precompute work. Threads are daemon so they don't
     // prevent JVM shutdown if a request is in flight at exit.
@@ -85,9 +69,7 @@ public class SimulationSessionService {
         this.simulationFactory = simulationFactory;
         this.binaryResponseSerializer = binaryResponseSerializer;
         this.zstdCompressor = zstdCompressor;
-        this.simulationMap = new ConcurrentHashMap<>();
-        this.lastAccessedAt = new ConcurrentHashMap<>();
-        this.nextChunkCache = new ConcurrentHashMap<>();
+        this.sessions = new ConcurrentHashMap<>();
     }
 
     public String createSimulation(
@@ -102,7 +84,7 @@ public class SimulationSessionService {
         // Reject before doing the expensive build (body wrappers, possible
         // Horizons fetches) if we're already at capacity. Soft check — a tiny
         // race can let a few past the cap, which is harmless for a heap guard.
-        if (simulationMap.size() >= MAX_CONCURRENT_SESSIONS) {
+        if (sessions.size() >= MAX_CONCURRENT_SESSIONS) {
             throw new SessionCapacityExceededException(
                     "Server at capacity (" + MAX_CONCURRENT_SESSIONS + " concurrent sessions)");
         }
@@ -118,35 +100,40 @@ public class SimulationSessionService {
                 keyframesPerKept,
                 targetSnapshotsPerChunk
         );
-        simulationMap.put(sessionID, simulation);
-        lastAccessedAt.put(sessionID, System.currentTimeMillis());
+        sessions.put(sessionID, new SimulationSessionState(
+                simulation, System.currentTimeMillis()));
         logger.info("sessionID: {}", sessionID);
         return sessionID;
     }
 
     public SimulationResponseDTO returnSimulationResponseDTO(String sessionID) {
-        Simulation simulation = simulationMap.get(sessionID);
+        Simulation simulation = getSimulation(sessionID);
+        if (simulation == null) {
+            throw sessionNotFound(sessionID);
+        }
         List<CelestialBodyWrapper> celestialBodyList = simulation.getCelestialBodies();
-        SimulationResponseMetadata simulationResponseMetadata = new SimulationResponseMetadata(sessionID);
-        return new SimulationResponseDTO(celestialBodyList, simulationResponseMetadata);
+        SimulationResponseMetadata metadata = new SimulationResponseMetadata(sessionID);
+        return new SimulationResponseDTO(celestialBodyList, metadata);
     }
 
     public Simulation getSimulation(String sessionID) {
-        return simulationMap.get(sessionID);
+        SimulationSessionState state = sessions.get(sessionID);
+        return state == null ? null : state.liveSimulation();
     }
 
     public List<Simulation> getAllSimulations() {
-        return new ArrayList<>(simulationMap.values());
+        List<Simulation> simulations = new ArrayList<>();
+        for (SimulationSessionState state : sessions.values()) {
+            Simulation simulation = state.liveSimulation();
+            if (simulation != null) {
+                simulations.add(simulation);
+            }
+        }
+        return simulations;
     }
 
     public void removeSimulation(String sessionID) {
-        simulationMap.remove(sessionID);
-        lastAccessedAt.remove(sessionID);
-        CompletableFuture<byte[]> pending = nextChunkCache.remove(sessionID);
-        if (pending != null) {
-            pending.cancel(true);
-        }
-        clearChunkProtocolState(sessionID);
+        closeSession(sessionID, sessions.get(sessionID));
     }
 
     /**
@@ -156,86 +143,87 @@ public class SimulationSessionService {
      * session at a time (no interleaved state corruption). The index gate makes the
      * call idempotent: a request for the last-served index re-serves the cached
      * bytes without advancing; the next sequential index produces and advances;
-     * anything else is a conflict. Always kicks off the next precompute after
-     * producing, so subsequent calls hit cache.
+     * anything else is a conflict. Result publication and next-chunk precompute
+     * are atomic with session closure, so late work cannot restore a dead session.
      */
     public byte[] getNextChunkBytes(String sessionID, int expectedChunkIndex) {
-        Simulation simulation = simulationMap.get(sessionID);
-        if (simulation == null) {
-            // Evicted, released, or never existed. Throw BEFORE touching
-            // lastAccessedAt: resurrecting a dead session's idle clock on every
-            // retry would defeat eviction.
-            throw new SessionNotFoundException("No live session for ID: " + sessionID);
+        SimulationSessionState state = sessions.get(sessionID);
+        if (state == null || !state.touchIfOpen(System.currentTimeMillis())) {
+            throw sessionNotFound(sessionID);
         }
-        lastAccessedAt.put(sessionID, System.currentTimeMillis());
 
-        ReentrantLock lock = sessionLocks.computeIfAbsent(sessionID, id -> new ReentrantLock());
+        Simulation simulation = state.simulationForWork();
+        ReentrantLock lock = state.requestLock();
         lock.lock();
         try {
-            int served = servedChunkIndex.getOrDefault(sessionID, -1);
-
-            // Idempotent retry: the client is re-requesting the chunk it was last
-            // served but never received (its fetch died after we computed). Re-serve
-            // the cached bytes without advancing the cursor.
-            if (expectedChunkIndex == served) {
-                byte[] cached = lastChunkBytes.get(sessionID);
-                if (cached != null) {
-                    return cached;
-                }
-                // served set but bytes absent should never happen; recomputing would
-                // double-advance, so surface it rather than corrupt the timeline.
-                throw new ChunkIndexConflictException(expectedChunkIndex, served);
+            SimulationSessionState.ChunkReservation reservation =
+                    state.reserveChunk(expectedChunkIndex);
+            if (reservation.isRetry()) {
+                return reservation.retryPayload();
             }
 
-            // Anything other than the next sequential chunk: cursors diverged by
-            // more than the one re-servable step. Never silently advance.
-            if (expectedChunkIndex != served + 1) {
-                throw new ChunkIndexConflictException(expectedChunkIndex, served);
-            }
-
-            // Produce the next chunk: consume the precompute future if present
-            // (common case), else compute on this thread (first request or
-            // post-eviction). The lock is held across get(); the precompute task
-            // does not take the lock, so there is no deadlock, and concurrent
-            // same-session requests serialize as intended.
-            CompletableFuture<byte[]> cached = nextChunkCache.remove(sessionID);
+            CompletableFuture<byte[]> cached = reservation.precomputedChunk();
             byte[] payload;
             try {
-                if (cached != null) {
-                    payload = cached.get();
-                } else {
-                    payload = computeChunkBytes(sessionID);
-                }
+                payload = cached != null
+                        ? cached.get()
+                        : computeChunkBytes(simulation);
             } catch (InterruptedException e) {
-                cached.cancel(true);
+                if (cached != null) {
+                    cached.cancel(true);
+                }
                 Thread.currentThread().interrupt();
-                removeSimulation(sessionID);
+                closeSession(sessionID, state);
                 throw new RuntimeException("Interrupted while awaiting precomputed chunk", e);
             } catch (ExecutionException e) {
-                removeSimulation(sessionID);
+                closeSession(sessionID, state);
                 throw new RuntimeException("Precompute failed", e.getCause());
             } catch (RuntimeException e) {
                 // Simulation.run() advances mutable state before serialization and
                 // compression. Once either post-run step fails, retrying this index
                 // would compute from a later state and silently skip an interval.
                 // Invalidate the session so the client must initialize a fresh one.
-                removeSimulation(sessionID);
+                closeSession(sessionID, state);
                 throw e;
             }
 
-            servedChunkIndex.put(sessionID, expectedChunkIndex);
-            lastChunkBytes.put(sessionID, payload);
-            kickOffNextPrecompute(sessionID);
+            try {
+                boolean published = state.publishChunk(
+                        expectedChunkIndex,
+                        payload,
+                        () -> startPrecompute(simulation));
+                if (!published) {
+                    throw sessionNotFound(sessionID);
+                }
+            } catch (SessionNotFoundException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                closeSession(sessionID, state);
+                throw e;
+            }
             return payload;
         } finally {
             lock.unlock();
         }
     }
 
-    private void clearChunkProtocolState(String sessionID) {
-        servedChunkIndex.remove(sessionID);
-        lastChunkBytes.remove(sessionID);
-        sessionLocks.remove(sessionID);
+    private void closeSession(String sessionID, SimulationSessionState state) {
+        if (state == null) {
+            return;
+        }
+        SimulationSessionState.Closure closure = state.close();
+        sessions.remove(sessionID, state);
+        cancelPrecompute(closure.pendingPrecompute());
+    }
+
+    private static void cancelPrecompute(CompletableFuture<byte[]> pending) {
+        if (pending != null) {
+            pending.cancel(true);
+        }
+    }
+
+    private SessionNotFoundException sessionNotFound(String sessionID) {
+        return new SessionNotFoundException("No live session for ID: " + sessionID);
     }
 
     /**
@@ -244,21 +232,17 @@ public class SimulationSessionService {
      * use {@link #getNextChunkBytes}.
      */
     public CompletableFuture<byte[]> peekPrecomputedChunk(String sessionID) {
-        return nextChunkCache.get(sessionID);
+        SimulationSessionState state = sessions.get(sessionID);
+        return state == null ? null : state.peekPrecomputedChunk();
     }
 
-    private void kickOffNextPrecompute(String sessionID) {
-        // computeIfAbsent prevents double-kickoff if a caller races with us.
-        nextChunkCache.computeIfAbsent(sessionID, id ->
-                CompletableFuture.supplyAsync(() -> computeChunkBytes(id), precomputeExecutor));
+    private CompletableFuture<byte[]> startPrecompute(Simulation simulation) {
+        return CompletableFuture.supplyAsync(
+                () -> computeChunkBytes(simulation),
+                precomputeExecutor);
     }
 
-    private byte[] computeChunkBytes(String sessionID) {
-        Simulation simulation = getSimulation(sessionID);
-        if (simulation == null) {
-            throw new IllegalArgumentException("Simulation not found for session ID: " + sessionID);
-        }
-
+    private byte[] computeChunkBytes(Simulation simulation) {
         ChunkResult chunkResult = simulation.run();
 
         // µ map built fresh each chunk; constant per session but cheap (~9 entries).
@@ -284,20 +268,17 @@ public class SimulationSessionService {
     @Scheduled(fixedRate = 60_000)
     public void evictIdleSimulations() {
         long now = System.currentTimeMillis();
-        Iterator<Map.Entry<String, Long>> it = lastAccessedAt.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<String, Long> entry = it.next();
-            if (now - entry.getValue() > IDLE_TIMEOUT_MS) {
-                String sessionID = entry.getKey();
-                simulationMap.remove(sessionID);
-                CompletableFuture<byte[]> pending = nextChunkCache.remove(sessionID);
-                if (pending != null) {
-                    pending.cancel(true);
-                }
-                it.remove();
-                clearChunkProtocolState(sessionID);
-                logger.info("Evicted idle simulation {}", sessionID);
+        for (Map.Entry<String, SimulationSessionState> entry : sessions.entrySet()) {
+            String sessionID = entry.getKey();
+            SimulationSessionState state = entry.getValue();
+            SimulationSessionState.Closure closure =
+                    state.closeIfIdle(now, IDLE_TIMEOUT_MS);
+            if (!closure.closedNow()) {
+                continue;
             }
+            sessions.remove(sessionID, state);
+            cancelPrecompute(closure.pendingPrecompute());
+            logger.info("Evicted idle simulation {}", sessionID);
         }
     }
 }

--- a/backend/src/main/java/personal/spacesim/services/SimulationSessionState.java
+++ b/backend/src/main/java/personal/spacesim/services/SimulationSessionState.java
@@ -1,0 +1,141 @@
+package personal.spacesim.services;
+
+import personal.spacesim.simulation.Simulation;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+/**
+ * Owns every mutable value whose validity is tied to one live simulation
+ * session. Synchronized methods form the short lifecycle boundary for touch,
+ * reservation, publication, and closure. Expensive chunk production runs
+ * outside this monitor under {@link #requestLock}, then publishes only if the
+ * state is still open.
+ */
+final class SimulationSessionState {
+
+    record ChunkReservation(
+            byte[] retryPayload,
+            CompletableFuture<byte[]> precomputedChunk
+    ) {
+        static ChunkReservation retry(byte[] payload) {
+            return new ChunkReservation(payload, null);
+        }
+
+        static ChunkReservation produce(CompletableFuture<byte[]> precomputedChunk) {
+            return new ChunkReservation(null, precomputedChunk);
+        }
+
+        boolean isRetry() {
+            return retryPayload != null;
+        }
+    }
+
+    record Closure(
+            boolean closedNow,
+            CompletableFuture<byte[]> pendingPrecompute
+    ) {
+        static Closure noChange() {
+            return new Closure(false, null);
+        }
+    }
+
+    private final Simulation simulation;
+    private final ReentrantLock requestLock = new ReentrantLock();
+    private long lastAccessedAt;
+    private int servedChunkIndex = -1;
+    private byte[] lastChunkBytes;
+    private CompletableFuture<byte[]> nextChunkFuture;
+    private boolean closed;
+
+    SimulationSessionState(Simulation simulation, long createdAt) {
+        this.simulation = Objects.requireNonNull(simulation);
+        this.lastAccessedAt = createdAt;
+    }
+
+    ReentrantLock requestLock() {
+        return requestLock;
+    }
+
+    Simulation simulationForWork() {
+        return simulation;
+    }
+
+    synchronized Simulation liveSimulation() {
+        return closed ? null : simulation;
+    }
+
+    synchronized boolean touchIfOpen(long now) {
+        if (closed) {
+            return false;
+        }
+        lastAccessedAt = now;
+        return true;
+    }
+
+    synchronized ChunkReservation reserveChunk(int expectedChunkIndex) {
+        ensureOpen();
+        if (expectedChunkIndex == servedChunkIndex) {
+            if (lastChunkBytes != null) {
+                return ChunkReservation.retry(lastChunkBytes);
+            }
+            throw new ChunkIndexConflictException(expectedChunkIndex, servedChunkIndex);
+        }
+        if (expectedChunkIndex != servedChunkIndex + 1) {
+            throw new ChunkIndexConflictException(expectedChunkIndex, servedChunkIndex);
+        }
+        CompletableFuture<byte[]> precomputed = nextChunkFuture;
+        nextChunkFuture = null;
+        return ChunkReservation.produce(precomputed);
+    }
+
+    synchronized boolean publishChunk(
+            int chunkIndex,
+            byte[] payload,
+            Supplier<CompletableFuture<byte[]>> nextFutureFactory
+    ) {
+        if (closed) {
+            return false;
+        }
+        CompletableFuture<byte[]> next = Objects.requireNonNull(nextFutureFactory.get());
+        servedChunkIndex = chunkIndex;
+        lastChunkBytes = payload;
+        nextChunkFuture = next;
+        return true;
+    }
+
+    synchronized Closure close() {
+        if (closed) {
+            return Closure.noChange();
+        }
+        return closeInternal();
+    }
+
+    synchronized Closure closeIfIdle(long now, long idleTimeoutMs) {
+        if (closed || now - lastAccessedAt <= idleTimeoutMs) {
+            return Closure.noChange();
+        }
+        return closeInternal();
+    }
+
+    synchronized CompletableFuture<byte[]> peekPrecomputedChunk() {
+        return closed ? null : nextChunkFuture;
+    }
+
+    private Closure closeInternal() {
+        closed = true;
+        CompletableFuture<byte[]> pending = nextChunkFuture;
+        nextChunkFuture = null;
+        servedChunkIndex = -1;
+        lastChunkBytes = null;
+        return new Closure(true, pending);
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            throw new SessionNotFoundException("Session is closed");
+        }
+    }
+}

--- a/backend/src/test/java/personal/spacesim/services/SimulationSessionLifecycleConcurrencyTest.java
+++ b/backend/src/test/java/personal/spacesim/services/SimulationSessionLifecycleConcurrencyTest.java
@@ -9,17 +9,21 @@ import personal.spacesim.utils.compressor.ZstdCompressor;
 import personal.spacesim.utils.serializers.BinaryResponseSerializer;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
+import java.util.function.LongSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -106,7 +110,57 @@ class SimulationSessionLifecycleConcurrencyTest {
         }
     }
 
+    @Test
+    void idleEvictionReturnsWhilePrecomputeRunsAndLateCompletionStaysDiscarded()
+            throws Exception {
+        AtomicLong now = new AtomicLong(0L);
+        Harness harness = newHarness(now::get);
+        CountDownLatch precomputeStarted = new CountDownLatch(1);
+        CountDownLatch allowPrecomputeToFinish = new CountDownLatch(1);
+        CountDownLatch precomputeFinished = new CountDownLatch(1);
+        when(harness.simulation().run()).thenReturn(harness.chunkResult()).thenAnswer(invocation -> {
+            precomputeStarted.countDown();
+            try {
+                allowPrecomputeToFinish.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                precomputeFinished.countDown();
+            }
+            return harness.chunkResult();
+        });
+
+        assertArrayEquals(COMPRESSED_CHUNK,
+                harness.service().getNextChunkBytes(harness.sessionID(), 0));
+        assertTrue(precomputeStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        CompletableFuture<byte[]> pending =
+                harness.service().peekPrecomputedChunk(harness.sessionID());
+        assertNotNull(pending);
+
+        now.set(TimeUnit.MINUTES.toMillis(16));
+        ExecutorService evictionExecutor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> eviction = evictionExecutor.submit(
+                    harness.service()::evictIdleSimulations);
+            eviction.get(1, TimeUnit.SECONDS);
+
+            assertTrue(pending.isCancelled());
+            assertReleased(harness);
+
+            allowPrecomputeToFinish.countDown();
+            assertTrue(precomputeFinished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            assertReleased(harness);
+        } finally {
+            allowPrecomputeToFinish.countDown();
+            evictionExecutor.shutdownNow();
+        }
+    }
+
     private static Harness newHarness() {
+        return newHarness(System::currentTimeMillis);
+    }
+
+    private static Harness newHarness(LongSupplier currentTimeMillis) {
         SimulationFactory simulationFactory = mock(SimulationFactory.class);
         BinaryResponseSerializer serializer = mock(BinaryResponseSerializer.class);
         ZstdCompressor compressor = mock(ZstdCompressor.class);
@@ -122,7 +176,7 @@ class SimulationSessionLifecycleConcurrencyTest {
         when(compressor.compress(any(byte[].class))).thenReturn(COMPRESSED_CHUNK);
 
         SimulationSessionService service = new SimulationSessionService(
-                simulationFactory, serializer, compressor);
+                simulationFactory, serializer, compressor, currentTimeMillis);
         String sessionID = service.createSimulation(
                 List.of("Sun"), "ICRF", "EULER", AbsoluteDate.J2000_EPOCH,
                 "days", 1, 1);

--- a/backend/src/test/java/personal/spacesim/services/SimulationSessionLifecycleConcurrencyTest.java
+++ b/backend/src/test/java/personal/spacesim/services/SimulationSessionLifecycleConcurrencyTest.java
@@ -1,0 +1,159 @@
+package personal.spacesim.services;
+
+import org.junit.jupiter.api.Test;
+import org.orekit.time.AbsoluteDate;
+import personal.spacesim.simulation.ChunkResult;
+import personal.spacesim.simulation.Simulation;
+import personal.spacesim.simulation.SimulationFactory;
+import personal.spacesim.utils.compressor.ZstdCompressor;
+import personal.spacesim.utils.serializers.BinaryResponseSerializer;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SimulationSessionLifecycleConcurrencyTest {
+
+    private static final byte[] COMPRESSED_CHUNK = {2};
+    private static final long TIMEOUT_SECONDS = 5;
+
+    @Test
+    void releaseDuringForegroundComputeRejectsLateResult() throws Exception {
+        Harness harness = newHarness();
+        CountDownLatch runStarted = new CountDownLatch(1);
+        CountDownLatch allowRunToFinish = new CountDownLatch(1);
+        when(harness.simulation().run()).thenAnswer(invocation -> {
+            runStarted.countDown();
+            assertTrue(allowRunToFinish.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            return harness.chunkResult();
+        });
+
+        ExecutorService requestExecutor = Executors.newSingleThreadExecutor();
+        try {
+            Future<byte[]> response = requestExecutor.submit(
+                    () -> harness.service().getNextChunkBytes(harness.sessionID(), 0));
+            assertTrue(runStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+            harness.service().removeSimulation(harness.sessionID());
+            allowRunToFinish.countDown();
+
+            ExecutionException failure = assertThrows(
+                    ExecutionException.class,
+                    () -> response.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            assertAll(
+                    () -> assertInstanceOf(SessionNotFoundException.class, failure.getCause()),
+                    () -> assertReleased(harness)
+            );
+        } finally {
+            allowRunToFinish.countDown();
+            requestExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void releaseWhileRequestAwaitsPrecomputeRejectsLateResult() throws Exception {
+        Harness harness = newHarness();
+        CountDownLatch precomputeStarted = new CountDownLatch(1);
+        CountDownLatch allowPrecomputeToFinish = new CountDownLatch(1);
+        when(harness.simulation().run()).thenReturn(harness.chunkResult()).thenAnswer(invocation -> {
+            precomputeStarted.countDown();
+            assertTrue(allowPrecomputeToFinish.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            return harness.chunkResult();
+        });
+
+        ExecutorService requestExecutor = Executors.newSingleThreadExecutor();
+        try {
+            assertArrayEquals(COMPRESSED_CHUNK,
+                    harness.service().getNextChunkBytes(harness.sessionID(), 0));
+            assertTrue(precomputeStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+            Future<byte[]> response = requestExecutor.submit(
+                    () -> harness.service().getNextChunkBytes(harness.sessionID(), 1));
+            awaitPrecomputeConsumption(harness.service(), harness.sessionID());
+
+            harness.service().removeSimulation(harness.sessionID());
+            allowPrecomputeToFinish.countDown();
+
+            ExecutionException failure = assertThrows(
+                    ExecutionException.class,
+                    () -> response.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+            assertAll(
+                    () -> assertInstanceOf(SessionNotFoundException.class, failure.getCause()),
+                    () -> assertReleased(harness)
+            );
+        } finally {
+            allowPrecomputeToFinish.countDown();
+            requestExecutor.shutdownNow();
+        }
+    }
+
+    private static Harness newHarness() {
+        SimulationFactory simulationFactory = mock(SimulationFactory.class);
+        BinaryResponseSerializer serializer = mock(BinaryResponseSerializer.class);
+        ZstdCompressor compressor = mock(ZstdCompressor.class);
+        Simulation simulation = mock(Simulation.class);
+        ChunkResult chunkResult = mock(ChunkResult.class);
+
+        when(simulationFactory.createSimulation(
+                anyString(), anyList(), anyString(), anyString(),
+                any(AbsoluteDate.class), anyString(), anyInt(), anyInt()))
+                .thenReturn(simulation);
+        when(simulation.getCelestialBodies()).thenReturn(List.of());
+        when(serializer.serialize(any(ChunkResult.class), any())).thenReturn(new byte[]{1});
+        when(compressor.compress(any(byte[].class))).thenReturn(COMPRESSED_CHUNK);
+
+        SimulationSessionService service = new SimulationSessionService(
+                simulationFactory, serializer, compressor);
+        String sessionID = service.createSimulation(
+                List.of("Sun"), "ICRF", "EULER", AbsoluteDate.J2000_EPOCH,
+                "days", 1, 1);
+        return new Harness(service, simulation, chunkResult, sessionID);
+    }
+
+    private static void awaitPrecomputeConsumption(
+            SimulationSessionService service,
+            String sessionID
+    ) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS);
+        while (service.peekPrecomputedChunk(sessionID) != null) {
+            if (System.nanoTime() >= deadline) {
+                fail("request did not consume the precompute future before timeout");
+            }
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+        }
+    }
+
+    private static void assertReleased(Harness harness) {
+        assertNull(harness.service().getSimulation(harness.sessionID()));
+        assertNull(harness.service().peekPrecomputedChunk(harness.sessionID()));
+        assertTrue(harness.service().getAllSimulations().isEmpty());
+        assertThrows(SessionNotFoundException.class,
+                () -> harness.service().getNextChunkBytes(harness.sessionID(), 0));
+    }
+
+    private record Harness(
+            SimulationSessionService service,
+            Simulation simulation,
+            ChunkResult chunkResult,
+            String sessionID
+    ) {}
+}


### PR DESCRIPTION
## Summary\n- consolidate per-session lifecycle state behind one atomic close boundary\n- discard chunk results that finish after release or idle eviction\n- add deterministic concurrency coverage for foreground, precompute, and eviction races\n\n## Verification\n- [INFO] Scanning for projects...
[INFO] 
[INFO] -------------------------< personal:spacesim >--------------------------
[INFO] Building spacesim 0.0.1-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- clean:3.4.1:clean (default-clean) @ spacesim ---
[INFO] Deleting /Users/byeonkho/.codex/worktrees/22d9/spacesim/backend/target
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ spacesim ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] Copying 350 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.14.0:compile (default-compile) @ spacesim ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 51 source files with javac [debug parameters release 21] to target/classes
[INFO] /Users/byeonkho/.codex/worktrees/22d9/spacesim/backend/src/main/java/personal/spacesim/apis/filters/RateLimitFilter.java: /Users/byeonkho/.codex/worktrees/22d9/spacesim/backend/src/main/java/personal/spacesim/apis/filters/RateLimitFilter.java uses or overrides a deprecated API.
[INFO] /Users/byeonkho/.codex/worktrees/22d9/spacesim/backend/src/main/java/personal/spacesim/apis/filters/RateLimitFilter.java: Recompile with -Xlint:deprecation for details.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ spacesim ---
[INFO] Copying 1 resource from src/test/resources to target/test-classes
[INFO] 
[INFO] --- compiler:3.14.0:testCompile (default-testCompile) @ spacesim ---
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 44 source files with javac [debug parameters release 21] to target/test-classes
[INFO] 
[INFO] --- surefire:3.5.3:test (default-test) @ spacesim ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running personal.spacesim.tools.OrekitEphemerisRegressionTest
20:44:14.592 [main] INFO org.springframework.test.context.support.AnnotationConfigContextLoaderUtils -- Could not detect default configuration classes for test class [personal.spacesim.tools.OrekitEphemerisRegressionTest]: OrekitEphemerisRegressionTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
20:44:14.641 [main] INFO org.springframework.boot.test.context.SpringBootTestContextBootstrapper -- Found @SpringBootConfiguration personal.spacesim.SpacesimApplication for test class personal.spacesim.tools.OrekitEphemerisRegressionTest
20:44:14.682 [main] INFO org.springframework.boot.devtools.restart.RestartApplicationListener -- Restart disabled due to context in which it is running

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.5.0)

2026-07-15T20:44:14.772+08:00  INFO 24180 --- [spacesim] [           main] p.s.tools.OrekitEphemerisRegressionTest  : Starting OrekitEphemerisRegressionTest using Java 25.0.3 with PID 24180 (started by byeonkho in /Users/byeonkho/.codex/worktrees/22d9/spacesim/backend)
2026-07-15T20:44:14.773+08:00  INFO 24180 --- [spacesim] [           main] p.s.tools.OrekitEphemerisRegressionTest  : No active profile set, falling back to 1 default profile: "default"
2026-07-15T20:44:15.351+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:15.352+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning horizons-cache
2026-07-15T20:44:15.355+08:00  WARN 24180 --- [spacesim] [           main] p.s.apis.filters.OriginLockFilter        : Origin lock disabled (spacesim.origin-secret unset): /api is reachable directly, not only via Cloudflare. Set the secret in production.
2026-07-15T20:44:15.360+08:00  INFO 24180 --- [spacesim] [           main] personal.spacesim.config.AppConfig       : Initializing Orekit data...
2026-07-15T20:44:15.365+08:00  INFO 24180 --- [spacesim] [           main] personal.spacesim.config.AppConfig       : Orekit data initialized from: /Users/byeonkho/.codex/worktrees/22d9/spacesim/backend/target/classes/orekit-data-master
2026-07-15T20:44:15.433+08:00  INFO 24180 --- [spacesim] [           main] o.s.v.b.OptionalValidatorFactoryBean     : Failed to set up a Bean Validation provider: jakarta.validation.NoProviderFoundException: Unable to create a Configuration, because no Jakarta Bean Validation provider could be found. Add a provider like Hibernate Validator (RI) to your classpath.
2026-07-15T20:44:15.631+08:00  INFO 24180 --- [spacesim] [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
2026-07-15T20:44:15.671+08:00  INFO 24180 --- [spacesim] [           main] p.s.tools.OrekitEphemerisRegressionTest  : Started OrekitEphemerisRegressionTest in 0.992 seconds (process running for 1.404)
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.583 s -- in personal.spacesim.tools.OrekitEphemerisRegressionTest
[INFO] Running personal.spacesim.tools.InitialPositionTest
2026-07-15T20:44:16.106+08:00  INFO 24180 --- [spacesim] [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [personal.spacesim.tools.InitialPositionTest]: InitialPositionTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-07-15T20:44:16.107+08:00  INFO 24180 --- [spacesim] [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration personal.spacesim.SpacesimApplication for test class personal.spacesim.tools.InitialPositionTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.068 s -- in personal.spacesim.tools.InitialPositionTest
[INFO] Running personal.spacesim.apis.filters.OriginLockFilterTest
2026-07-15T20:44:16.176+08:00  WARN 24180 --- [spacesim] [           main] p.s.apis.filters.OriginLockFilter        : Origin lock disabled (spacesim.origin-secret unset): /api is reachable directly, not only via Cloudflare. Set the secret in production.
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in personal.spacesim.apis.filters.OriginLockFilterTest
[INFO] Running personal.spacesim.apis.filters.RateLimitFilterTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in personal.spacesim.apis.filters.RateLimitFilterTest
[INFO] Running personal.spacesim.apis.GroundTruthControllerTest
2026-07-15T20:44:16.188+08:00  INFO 24180 --- [spacesim] [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [personal.spacesim.apis.GroundTruthControllerTest]: GroundTruthControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-07-15T20:44:16.194+08:00  INFO 24180 --- [spacesim] [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration personal.spacesim.SpacesimApplication for test class personal.spacesim.apis.GroundTruthControllerTest
2026-07-15T20:44:16.197+08:00  INFO 24180 --- [spacesim] [           main] o.s.b.d.r.RestartApplicationListener     : Restart disabled due to context in which it is running

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.5.0)

2026-07-15T20:44:16.208+08:00  INFO 24180 --- [spacesim] [           main] p.s.apis.GroundTruthControllerTest       : Starting GroundTruthControllerTest using Java 25.0.3 with PID 24180 (started by byeonkho in /Users/byeonkho/.codex/worktrees/22d9/spacesim/backend)
2026-07-15T20:44:16.208+08:00  INFO 24180 --- [spacesim] [           main] p.s.apis.GroundTruthControllerTest       : No active profile set, falling back to 1 default profile: "default"
2026-07-15T20:44:16.331+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:16.332+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning horizons-cache
2026-07-15T20:44:16.333+08:00  WARN 24180 --- [spacesim] [           main] p.s.apis.filters.OriginLockFilter        : Origin lock disabled (spacesim.origin-secret unset): /api is reachable directly, not only via Cloudflare. Set the secret in production.
2026-07-15T20:44:16.333+08:00  INFO 24180 --- [spacesim] [           main] personal.spacesim.config.AppConfig       : Initializing Orekit data...
2026-07-15T20:44:16.333+08:00  INFO 24180 --- [spacesim] [           main] personal.spacesim.config.AppConfig       : Orekit data initialized from: /Users/byeonkho/.codex/worktrees/22d9/spacesim/backend/target/classes/orekit-data-master
2026-07-15T20:44:16.345+08:00  INFO 24180 --- [spacesim] [           main] o.s.v.b.OptionalValidatorFactoryBean     : Failed to set up a Bean Validation provider: jakarta.validation.NoProviderFoundException: Unable to create a Configuration, because no Jakarta Bean Validation provider could be found. Add a provider like Hibernate Validator (RI) to your classpath.
2026-07-15T20:44:16.386+08:00  INFO 24180 --- [spacesim] [           main] o.s.b.t.m.w.SpringBootMockServletContext : Initializing Spring TestDispatcherServlet ''
2026-07-15T20:44:16.387+08:00  INFO 24180 --- [spacesim] [           main] o.s.t.web.servlet.TestDispatcherServlet  : Initializing Servlet ''
2026-07-15T20:44:16.387+08:00  INFO 24180 --- [spacesim] [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
2026-07-15T20:44:16.389+08:00  INFO 24180 --- [spacesim] [           main] o.s.t.web.servlet.TestDispatcherServlet  : Completed initialization in 2 ms
2026-07-15T20:44:16.397+08:00  INFO 24180 --- [spacesim] [           main] p.s.apis.GroundTruthControllerTest       : Started GroundTruthControllerTest in 0.2 seconds (process running for 2.131)
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.291 s -- in personal.spacesim.apis.GroundTruthControllerTest
[INFO] Running personal.spacesim.apis.HttpCompressionTest
2026-07-15T20:44:16.480+08:00  INFO 24180 --- [spacesim] [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [personal.spacesim.apis.HttpCompressionTest]: HttpCompressionTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-07-15T20:44:16.480+08:00  INFO 24180 --- [spacesim] [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration personal.spacesim.SpacesimApplication for test class personal.spacesim.apis.HttpCompressionTest
2026-07-15T20:44:16.482+08:00  INFO 24180 --- [spacesim] [           main] o.s.b.d.r.RestartApplicationListener     : Restart disabled due to context in which it is running

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.5.0)

2026-07-15T20:44:16.490+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.apis.HttpCompressionTest      : Starting HttpCompressionTest using Java 25.0.3 with PID 24180 (started by byeonkho in /Users/byeonkho/.codex/worktrees/22d9/spacesim/backend)
2026-07-15T20:44:16.490+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.apis.HttpCompressionTest      : No active profile set, falling back to 1 default profile: "default"
2026-07-15T20:44:16.606+08:00  INFO 24180 --- [spacesim] [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 0 (http)
2026-07-15T20:44:16.610+08:00  INFO 24180 --- [spacesim] [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2026-07-15T20:44:16.611+08:00  INFO 24180 --- [spacesim] [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.41]
2026-07-15T20:44:16.623+08:00  INFO 24180 --- [spacesim] [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2026-07-15T20:44:16.624+08:00  INFO 24180 --- [spacesim] [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 133 ms
2026-07-15T20:44:16.632+08:00  WARN 24180 --- [spacesim] [           main] p.s.apis.filters.OriginLockFilter        : Origin lock disabled (spacesim.origin-secret unset): /api is reachable directly, not only via Cloudflare. Set the secret in production.
2026-07-15T20:44:16.650+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:16.650+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning horizons-cache
2026-07-15T20:44:16.651+08:00  INFO 24180 --- [spacesim] [           main] personal.spacesim.config.AppConfig       : Initializing Orekit data...
2026-07-15T20:44:16.651+08:00  INFO 24180 --- [spacesim] [           main] personal.spacesim.config.AppConfig       : Orekit data initialized from: /Users/byeonkho/.codex/worktrees/22d9/spacesim/backend/target/classes/orekit-data-master
2026-07-15T20:44:16.655+08:00  INFO 24180 --- [spacesim] [           main] o.s.v.b.OptionalValidatorFactoryBean     : Failed to set up a Bean Validation provider: jakarta.validation.NoProviderFoundException: Unable to create a Configuration, because no Jakarta Bean Validation provider could be found. Add a provider like Hibernate Validator (RI) to your classpath.
2026-07-15T20:44:16.677+08:00  INFO 24180 --- [spacesim] [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint beneath base path '/actuator'
2026-07-15T20:44:16.692+08:00  INFO 24180 --- [spacesim] [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 49733 (http) with context path '/'
2026-07-15T20:44:16.694+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.apis.HttpCompressionTest      : Started HttpCompressionTest in 0.212 seconds (process running for 2.429)
2026-07-15T20:44:16.729+08:00  INFO 24180 --- [spacesim] [omcat-handler-0] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
2026-07-15T20:44:16.730+08:00  INFO 24180 --- [spacesim] [omcat-handler-0] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
2026-07-15T20:44:16.730+08:00  INFO 24180 --- [spacesim] [omcat-handler-0] o.s.web.servlet.DispatcherServlet        : Completed initialization in 0 ms
2026-07-15T20:44:16.785+08:00  INFO 24180 --- [spacesim] [omcat-handler-0] p.s.services.SimulationSessionService    : sessionID: 3546feb6-f83b-45da-aaf5-285642479a75

=== HTTP compression: /ground-truth (1-year window) ===
  BEFORE (identity): 65,382 bytes (63.8 KB)
  AFTER  (gzip):     24,882 bytes (24.3 KB)  Content-Encoding=gzip
  reduction:         62% smaller
2026-07-15T20:44:16.858+08:00  INFO 24180 --- [spacesim] [omcat-handler-3] p.s.a.controller.SimulationController    : [3546feb6-f83b-45da-aaf5-285642479a75] Chunk request received (index 0)
2026-07-15T20:44:16.876+08:00  INFO 24180 --- [spacesim] [omcat-handler-3] p.spacesim.simulation.Simulation         : Simulation completed for 10000 hours in 0.017529292 seconds.
2026-07-15T20:44:16.876+08:00  INFO 24180 --- [spacesim] [omcat-handler-3] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:16.964+08:00  INFO 24180 --- [spacesim] [omcat-handler-3] p.s.a.controller.SimulationController    : [3546feb6-f83b-45da-aaf5-285642479a75] Chunk served in 105ms (142 KB)
=== /chunk (octet-stream) Content-Encoding = (none) (expected: not gzip) ===
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.488 s -- in personal.spacesim.apis.HttpCompressionTest
[INFO] Running personal.spacesim.apis.OpenApiContractTest
2026-07-15T20:44:16.968+08:00  INFO 24180 --- [spacesim] [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [personal.spacesim.apis.OpenApiContractTest]: OpenApiContractTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-07-15T20:44:16.969+08:00  INFO 24180 --- [spacesim] [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration personal.spacesim.SpacesimApplication for test class personal.spacesim.apis.OpenApiContractTest
2026-07-15T20:44:16.970+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation completed for 10000 hours in 0.006120084 seconds.
2026-07-15T20:44:16.970+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:17.050+08:00  INFO 24180 --- [spacesim] [           main] o.springdoc.api.AbstractOpenApiResource  : Init duration for springdoc-openapi is: 77 ms
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.093 s -- in personal.spacesim.apis.OpenApiContractTest
[INFO] Running personal.spacesim.apis.SimulationControllerTest
2026-07-15T20:44:17.061+08:00  INFO 24180 --- [spacesim] [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [personal.spacesim.apis.SimulationControllerTest]: SimulationControllerTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-07-15T20:44:17.062+08:00  INFO 24180 --- [spacesim] [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration personal.spacesim.SpacesimApplication for test class personal.spacesim.apis.SimulationControllerTest
2026-07-15T20:44:17.069+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: e86adb22-f1fd-42cd-9d87-e0c38467f63d
2026-07-15T20:44:17.071+08:00  INFO 24180 --- [spacesim] [           main] p.s.a.controller.SimulationController    : [e86adb22-f1fd-42cd-9d87-e0c38467f63d] Chunk request received (index 5)
2026-07-15T20:44:17.071+08:00  WARN 24180 --- [spacesim] [           main] p.s.a.controller.SimulationController    : [e86adb22-f1fd-42cd-9d87-e0c38467f63d] Chunk index conflict: expected 5 but server last served -1
2026-07-15T20:44:17.073+08:00  INFO 24180 --- [spacesim] [           main] p.s.a.controller.SimulationController    : [no-such-session] Chunk request received (index 0)
2026-07-15T20:44:17.074+08:00  INFO 24180 --- [spacesim] [           main] p.s.a.controller.SimulationController    : [no-such-session] Chunk request for gone session
2026-07-15T20:44:17.077+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: abf7e14d-badf-4fb7-80e0-c95a81ba134f
2026-07-15T20:44:17.078+08:00  WARN 24180 --- [spacesim] [           main] p.s.a.controller.SimulationController    : Rejecting /initialize with duplicate body name: earth
2026-07-15T20:44:17.080+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: b9a6ce4b-9b06-4301-8097-b73d48a66ef7
2026-07-15T20:44:17.081+08:00  WARN 24180 --- [spacesim] [           main] p.s.a.controller.SimulationController    : Rejecting /initialize with duplicate body name: CERES
2026-07-15T20:44:17.082+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: 085491f0-9c0b-4dad-9a56-ff27c6eee1f9
2026-07-15T20:44:17.083+08:00  INFO 24180 --- [spacesim] [           main] p.s.a.controller.SimulationController    : Released prior session 085491f0-9c0b-4dad-9a56-ff27c6eee1f9 on resubmit
2026-07-15T20:44:17.083+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: 2c2117a7-3e21-46e6-8b7c-f6e169dc4293
2026-07-15T20:44:17.085+08:00  INFO 24180 --- [spacesim] [           main] p.s.a.controller.SimulationController    : [085491f0-9c0b-4dad-9a56-ff27c6eee1f9] Chunk request received (index 0)
2026-07-15T20:44:17.085+08:00  INFO 24180 --- [spacesim] [           main] p.s.a.controller.SimulationController    : [085491f0-9c0b-4dad-9a56-ff27c6eee1f9] Chunk request for gone session
2026-07-15T20:44:17.086+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: e365be9b-795c-40fb-871c-73f6e4c37567
2026-07-15T20:44:17.087+08:00  INFO 24180 --- [spacesim] [           main] p.s.a.controller.SimulationController    : [e365be9b-795c-40fb-871c-73f6e4c37567] Chunk request received (index 0)
2026-07-15T20:44:17.088+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.001730417 seconds.
2026-07-15T20:44:17.088+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:17.092+08:00  INFO 24180 --- [spacesim] [           main] p.s.a.controller.SimulationController    : [e365be9b-795c-40fb-871c-73f6e4c37567] Chunk served in 5ms (0 KB)
2026-07-15T20:44:17.094+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.001543625 seconds.
2026-07-15T20:44:17.094+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.033 s -- in personal.spacesim.apis.SimulationControllerTest
[INFO] Running personal.spacesim.config.CorsConfigTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in personal.spacesim.config.CorsConfigTest
[INFO] Running personal.spacesim.constants.FidelityBucketTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in personal.spacesim.constants.FidelityBucketTest
[INFO] Running personal.spacesim.simulation.DP853StageCountTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in personal.spacesim.simulation.DP853StageCountTest
[INFO] Running personal.spacesim.simulation.body.horizons.HorizonsStateCacheTest
2026-07-15T20:44:17.113+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.114+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-2589782669287391549
2026-07-15T20:44:17.120+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.120+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-11727533376768802690
2026-07-15T20:44:17.124+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.124+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 30 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-8244372231580695370
2026-07-15T20:44:17.128+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.128+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-14575140724721278665
2026-07-15T20:44:17.130+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.130+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-2481760102880307279
2026-07-15T20:44:17.135+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.135+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-17755499511779964363
2026-07-15T20:44:17.138+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.139+08:00  WARN 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Skipping corrupt Horizons cache file /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-8356999521298408568/2000433_0.json: com.fasterxml.jackson.core.JsonParseException: Unexpected character ('n' (code 110)): was expecting double-quote to start field name
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 2]
2026-07-15T20:44:17.139+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 30 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-8356999521298408568
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s -- in personal.spacesim.simulation.body.horizons.HorizonsStateCacheTest
[INFO] Running personal.spacesim.simulation.body.horizons.HorizonsClientTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.468 s -- in personal.spacesim.simulation.body.horizons.HorizonsClientTest
[INFO] Running personal.spacesim.simulation.body.horizons.HorizonsStateCacheSeedTest
2026-07-15T20:44:17.611+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.611+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-14907165737116966949
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in personal.spacesim.simulation.body.horizons.HorizonsStateCacheSeedTest
[INFO] Running personal.spacesim.simulation.body.horizons.HorizonsResponseParserTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in personal.spacesim.simulation.body.horizons.HorizonsResponseParserTest
[INFO] Running personal.spacesim.simulation.body.CelestialBodyWrapperTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s -- in personal.spacesim.simulation.body.CelestialBodyWrapperTest
[INFO] Running personal.spacesim.simulation.body.MinorBodyCatalogTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in personal.spacesim.simulation.body.MinorBodyCatalogTest
[INFO] Running personal.spacesim.simulation.body.MoonCatalogTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in personal.spacesim.simulation.body.MoonCatalogTest
[INFO] Running personal.spacesim.simulation.body.CelestialBodyWrapperFactoryTest
2026-07-15T20:44:17.688+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.688+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-6412987410287680237
2026-07-15T20:44:17.711+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.711+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-18339269132001479333
2026-07-15T20:44:17.718+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.719+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-12719527469239243248
2026-07-15T20:44:17.729+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.730+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-3776601671941311104
2026-07-15T20:44:17.736+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.736+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-15076273810245830055
2026-07-15T20:44:17.740+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.740+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-17095763768212952603
2026-07-15T20:44:17.744+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.745+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-12430519176756274599
2026-07-15T20:44:17.749+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.749+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-8427335096185292131
2026-07-15T20:44:17.754+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.754+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-6040842643416114650
2026-07-15T20:44:17.757+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.757+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-7840475850482348288
2026-07-15T20:44:17.761+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.761+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-275286825508239695
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.146 s -- in personal.spacesim.simulation.body.CelestialBodyWrapperFactoryTest
[INFO] Running personal.spacesim.simulation.body.BodyCatalogTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in personal.spacesim.simulation.body.BodyCatalogTest
[INFO] Running personal.spacesim.simulation.SimulationFactoryTest
2026-07-15T20:44:17.771+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.771+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-11262905792953911450
2026-07-15T20:44:17.786+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.786+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-18429000021265982683
2026-07-15T20:44:17.791+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.791+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-10557542652399742824
2026-07-15T20:44:17.795+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.795+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-13641718422305020381
2026-07-15T20:44:17.798+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.798+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-17047294658636032517
2026-07-15T20:44:17.801+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.801+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-16659517003119904137
2026-07-15T20:44:17.805+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.805+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-6957413097591175640
2026-07-15T20:44:17.809+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Seeded 29 prebaked Horizons entries from classpath
2026-07-15T20:44:17.809+08:00  INFO 24180 --- [spacesim] [           main] p.s.s.body.horizons.HorizonsStateCache   : Horizons cache ready: 29 entries in memory after scanning /var/folders/zw/k6w9kzxs4hz6517x94r5r1lh0000gn/T/junit-9371886989127918957
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.044 s -- in personal.spacesim.simulation.SimulationFactoryTest
[INFO] Running personal.spacesim.simulation.state.NBodyDerivativesEnergyTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in personal.spacesim.simulation.state.NBodyDerivativesEnergyTest
[INFO] Running personal.spacesim.simulation.state.NBodyDerivativesTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in personal.spacesim.simulation.state.NBodyDerivativesTest
[INFO] Running personal.spacesim.simulation.state.GlobalStateTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in personal.spacesim.simulation.state.GlobalStateTest
[INFO] Running personal.spacesim.simulation.SimulationTelemetryTest
2026-07-15T20:44:17.831+08:00  INFO 24180 --- [spacesim] [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [personal.spacesim.simulation.SimulationTelemetryTest]: SimulationTelemetryTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-07-15T20:44:17.837+08:00  INFO 24180 --- [spacesim] [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration personal.spacesim.SpacesimApplication for test class personal.spacesim.simulation.SimulationTelemetryTest
2026-07-15T20:44:17.953+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 hours in 0.107182541 seconds.
2026-07-15T20:44:17.953+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:17.960+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 hours in 0.004402708 seconds.
2026-07-15T20:44:17.960+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.133 s -- in personal.spacesim.simulation.SimulationTelemetryTest
[INFO] Running personal.spacesim.simulation.SimulationTest
2026-07-15T20:44:17.964+08:00  INFO 24180 --- [spacesim] [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [personal.spacesim.simulation.SimulationTest]: SimulationTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-07-15T20:44:17.965+08:00  INFO 24180 --- [spacesim] [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration personal.spacesim.SpacesimApplication for test class personal.spacesim.simulation.SimulationTest
2026-07-15T20:44:18.089+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 weeks in 0.120657625 seconds.
2026-07-15T20:44:18.089+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.199+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 weeks in 0.106923041 seconds.
2026-07-15T20:44:18.199+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.311+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 weeks in 0.111580041 seconds.
2026-07-15T20:44:18.311+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.314+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 seconds in 7.86625E-4 seconds.
2026-07-15T20:44:18.314+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.314+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 seconds in 4.68167E-4 seconds.
2026-07-15T20:44:18.314+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.429+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 weeks in 0.112281042 seconds.
2026-07-15T20:44:18.429+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.541+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 weeks in 0.109929333 seconds.
2026-07-15T20:44:18.542+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.654+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 weeks in 0.110070542 seconds.
2026-07-15T20:44:18.654+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.656+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 seconds in 2.63875E-4 seconds.
2026-07-15T20:44:18.656+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.657+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 seconds in 3.85375E-4 seconds.
2026-07-15T20:44:18.657+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.658+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 seconds in 2.6725E-4 seconds.
2026-07-15T20:44:18.658+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.696 s -- in personal.spacesim.simulation.SimulationTest
[INFO] Running personal.spacesim.utils.compressor.ZstdCompressorTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in personal.spacesim.utils.compressor.ZstdCompressorTest
[INFO] Running personal.spacesim.utils.math.integrators.DP853IntegratorEvalCountTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in personal.spacesim.utils.math.integrators.DP853IntegratorEvalCountTest
[INFO] Running personal.spacesim.utils.math.integrators.DP853IntegratorTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in personal.spacesim.utils.math.integrators.DP853IntegratorTest
[INFO] Running personal.spacesim.utils.math.integrators.RK4IntegratorTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in personal.spacesim.utils.math.integrators.RK4IntegratorTest
[INFO] Running personal.spacesim.utils.math.integrators.EulerIntegratorTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s -- in personal.spacesim.utils.math.integrators.EulerIntegratorTest
[INFO] Running personal.spacesim.utils.serializers.BinaryResponseSerializerTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in personal.spacesim.utils.serializers.BinaryResponseSerializerTest
[INFO] Running personal.spacesim.assets.PresetClipAssetGeneratorTest
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0 s -- in personal.spacesim.assets.PresetClipAssetGeneratorTest
[INFO] Running personal.spacesim.services.SimulationSessionLifecycleConcurrencyTest
2026-07-15T20:44:18.773+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: e8c64e2f-eb4e-47f1-b071-1e5a87dff452
2026-07-15T20:44:18.780+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: 0f17c6bd-ac7b-493a-9261-51a2982ca022
2026-07-15T20:44:18.781+08:00  INFO 24180 --- [spacesim] [pool-5-thread-1] p.s.services.SimulationSessionService    : Evicted idle simulation 0f17c6bd-ac7b-493a-9261-51a2982ca022
2026-07-15T20:44:18.782+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: e67bd2df-3743-439e-a083-b9c76bd7e611
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.113 s -- in personal.spacesim.services.SimulationSessionLifecycleConcurrencyTest
[INFO] Running personal.spacesim.services.GroundTruthProviderTest
2026-07-15T20:44:18.785+08:00  INFO 24180 --- [spacesim] [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [personal.spacesim.services.GroundTruthProviderTest]: GroundTruthProviderTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-07-15T20:44:18.789+08:00  INFO 24180 --- [spacesim] [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration personal.spacesim.SpacesimApplication for test class personal.spacesim.services.GroundTruthProviderTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in personal.spacesim.services.GroundTruthProviderTest
[INFO] Running personal.spacesim.services.SimulationSessionServiceTest
2026-07-15T20:44:18.796+08:00  INFO 24180 --- [spacesim] [           main] t.c.s.AnnotationConfigContextLoaderUtils : Could not detect default configuration classes for test class [personal.spacesim.services.SimulationSessionServiceTest]: SimulationSessionServiceTest does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
2026-07-15T20:44:18.797+08:00  INFO 24180 --- [spacesim] [           main] .b.t.c.SpringBootTestContextBootstrapper : Found @SpringBootConfiguration personal.spacesim.SpacesimApplication for test class personal.spacesim.services.SimulationSessionServiceTest
2026-07-15T20:44:18.802+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: 6e69878c-c562-46fa-b4cd-9088ee886be3
2026-07-15T20:44:18.804+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.002749334 seconds.
2026-07-15T20:44:18.805+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.813+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.002101542 seconds.
2026-07-15T20:44:18.813+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.820+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: 3da62d91-949a-4905-b927-c00522b6a9ac
2026-07-15T20:44:18.822+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.002238625 seconds.
2026-07-15T20:44:18.823+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.829+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.001577625 seconds.
2026-07-15T20:44:18.829+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.832+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.002254708 seconds.
2026-07-15T20:44:18.832+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.834+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: 9e13428c-5a0c-421f-b320-4707cc91beca
2026-07-15T20:44:18.837+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: cd2a64f6-f931-4a72-9f8f-bc2a8e51900c
2026-07-15T20:44:18.840+08:00  INFO 24180 --- [spacesim] [pool-7-thread-1] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.002489709 seconds.
2026-07-15T20:44:18.841+08:00  INFO 24180 --- [spacesim] [pool-7-thread-1] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.844+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.001550333 seconds.
2026-07-15T20:44:18.844+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.846+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.001399125 seconds.
2026-07-15T20:44:18.846+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.848+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: 5f0bb002-1ef9-45fb-8cac-f39d066fcb7e
2026-07-15T20:44:18.850+08:00  INFO 24180 --- [spacesim] [           main] p.s.services.SimulationSessionService    : sessionID: bacea52f-8fae-40e0-83ad-9ba2dac7a922
2026-07-15T20:44:18.852+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.001648041 seconds.
2026-07-15T20:44:18.852+08:00  INFO 24180 --- [spacesim] [           main] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.855+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.001126375 seconds.
2026-07-15T20:44:18.855+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
2026-07-15T20:44:18.857+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation completed for 10000 days in 0.001030916 seconds.
2026-07-15T20:44:18.857+08:00  INFO 24180 --- [spacesim] [esim-precompute] p.spacesim.simulation.Simulation         : Simulation ran using frame: ICRF
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.061 s -- in personal.spacesim.services.SimulationSessionServiceTest
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 197, Failures: 0, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.944 s
[INFO] Finished at: 2026-07-15T20:44:21+08:00
[INFO] ------------------------------------------------------------------------\n- 
> frontend@0.1.0 test
> vitest run --run src/app/store/middleware/simulationRequestThunk.test.ts


 RUN  v4.1.5 /Users/byeonkho/.codex/worktrees/22d9/spacesim/frontend


 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  20:44:21
   Duration  461ms (transform 46ms, setup 0ms, import 62ms, tests 345ms, environment 0ms)