### PR TITLE
chore(ci): update actions and Node runtime

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -3,19 +3,23 @@ name: Backend CI
 on:
   push:
     branches: [master]
-    paths: [backend/**]
+    paths:
+      - backend/**
+      - .github/workflows/backend-ci.yml
   pull_request:
     branches: [master]
-    paths: [backend/**]
+    paths:
+      - backend/**
+      - .github/workflows/backend-ci.yml
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: temurin

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -3,21 +3,27 @@ name: Frontend CI
 on:
   push:
     branches: [master]
-    paths: [frontend/**, backend/openapi.json]
+    paths:
+      - frontend/**
+      - backend/openapi.json
+      - .github/workflows/frontend-ci.yml
   pull_request:
     branches: [master]
-    paths: [frontend/**, backend/openapi.json]
+    paths:
+      - frontend/**
+      - backend/openapi.json
+      - .github/workflows/frontend-ci.yml
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/ui-package-ci.yml
+++ b/.github/workflows/ui-package-ci.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: packages/ui/package-lock.json
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,7 +37,7 @@
         "@eslint/eslintrc": "^3.3.5",
         "@playwright/test": "^1.49.0",
         "@tailwindcss/postcss": "^4.2.4",
-        "@types/node": "^22.13.1",
+        "@types/node": "^24.0.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9.39.4",
@@ -3326,13 +3326,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/offscreencanvas": {
@@ -9401,9 +9401,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "@eslint/eslintrc": "^3.3.5",
     "@playwright/test": "^1.49.0",
     "@tailwindcss/postcss": "^4.2.4",
-    "@types/node": "^22.13.1",
+    "@types/node": "^24.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9.39.4",


### PR DESCRIPTION
## Summary
- update checkout to v7, setup-node to v7, and setup-java to v5
- run frontend and UI package CI on Node 24 while keeping backend on JDK 21
- update frontend @types/node to 24
- include backend and frontend workflow files in their own path filters so workflow-only changes exercise CI

## Verification
- frontend on Node 24.18: npm ci, build, lint, 49 files and 429 tests, generated API unchanged, production audit clean
- UI package on Node 24.18: npm ci, 13 files and 30 tests, package build, Storybook build, audit clean
- backend: ./mvnw verify -q
- parsed and asserted all three workflow YAML files

## References
- https://github.com/actions/checkout/releases/tag/v7.0.1
- https://github.com/actions/setup-node/releases/tag/v7.0.0
- https://github.com/actions/setup-java/releases/tag/v5.6.0