### PR TITLE
chore(deps): remove unused dotenv

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,6 @@
         "@types/three": "^0.185.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "dotenv": "^16.4.7",
         "lucide-react": "^1.14.0",
         "next": "^16.2.6",
         "prettier": "^3.4.2",
@@ -5000,18 +4999,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/draco3d": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,6 @@
     "@types/three": "^0.185.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "dotenv": "^16.4.7",
     "lucide-react": "^1.14.0",
     "next": "^16.2.6",
     "prettier": "^3.4.2",


### PR DESCRIPTION
## Summary
- remove the unused direct `dotenv` dependency from the frontend manifest and lockfile
- rely on Next.js environment loading, with no application or configuration imports of `dotenv`
- resolve the proposed dotenv v17 update by eliminating the unnecessary runtime package

## Verification
- clean `npm ci`
- npm dependency query confirms `dotenv` is not installed
- production dependency audit: 0 vulnerabilities
- frontend production build
- ESLint
- 49 Vitest files and 429 tests
- dependency and lockfile diff contains only the intended removal

Browser journeys were not run because this changes no UI or application code; the production build exercises the relevant Next.js configuration path.