### PR TITLE
chore(deps): update Eclipse Temurin to v25

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Build stage ----
-FROM eclipse-temurin:21-jdk AS builder
+FROM eclipse-temurin:25-jdk AS builder
 WORKDIR /app
 
 # Dependency layer (cached unless pom.xml changes)
@@ -11,7 +11,7 @@ COPY src src
 RUN ./mvnw package -DskipTests -q
 
 # ---- Runtime stage ----
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:25-jre
 WORKDIR /app
 
 COPY --from=builder /app/target/*.jar app.jar


### PR DESCRIPTION
## Summary

- update the backend build image from Eclipse Temurin 21 JDK to 25 JDK
- update the backend runtime image from Eclipse Temurin 21 JRE to 25 JRE
- retain Java 21 as the project source and bytecode target

## Tradeoffs and risk

- Java 25 is the new container runtime, while backend CI retains Java 21 as the minimum supported build baseline
- the production image was therefore tested separately under Java 25 and a 1 GiB container limit
- Java 25 emits forward-looking native-access warnings for zstd-jni and warnings from some build/test tooling; these do not fail on Java 25 but may require library or JVM-flag changes before a future JDK upgrade

## Verification

- `./mvnw clean verify -q` on Temurin 25.0.3: 197 tests, 0 failures, 0 errors, 1 skipped
- `docker build --pull --tag spacesim-backend:temurin25-pr .`
- container runtime: Temurin 25.0.3, non-root user 1001:1001
- `/actuator/health`: UP in about 2 seconds
- 1 GiB container: estimated max heap 694.12 MiB; about 261 MiB used after a representative chunk
- initialize plus chunk smoke: HTTP 200, 146,052-byte zstd payload, no extra content encoding
- resulting local image size: 202,056,686 bytes